### PR TITLE
Add basic docs on supported Nexus classes

### DIFF
--- a/docs/getting-started/installation.rst
+++ b/docs/getting-started/installation.rst
@@ -1,0 +1,30 @@
+.. _installation:
+
+Installation
+============
+
+Scippnexus requires Python 3.8 or above.
+
+Conda
+-----
+
+Packages from `Anaconda Cloud <https://conda.anaconda.org/scipp>`_ are available for Linux, macOS, and Windows.
+
+.. code-block:: sh
+
+   conda install -c scipp scippnexus
+
+Pip
+---
+
+Scippnexus is available from `PyPI <https://pypi.org/>`_ via ``pip``:
+
+.. code-block:: sh
+
+   pip install scippnexus
+
+
+See also
+--------
+
+See also the `scipp installation instructions <https://scipp.github.io/getting-started/installation.html>`_ on how to setup a conda environment and how to install additional dependencies such plotting libraries or Jupyter.

--- a/docs/getting-started/installation.rst
+++ b/docs/getting-started/installation.rst
@@ -12,7 +12,7 @@ Packages from `Anaconda Cloud <https://conda.anaconda.org/scipp>`_ are available
 
 .. code-block:: sh
 
-   conda install -c scipp scippnexus
+   conda install -c conda-forge -c scipp scippnexus
 
 Pip
 ---

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -50,4 +50,5 @@ Get in touch
    :hidden:
    :maxdepth: 3
 
+   user-guide/nexus-classes
    user-guide/classes

--- a/docs/user-guide/classes.rst
+++ b/docs/user-guide/classes.rst
@@ -11,9 +11,21 @@ Data Structures
    :template: scipp-class-template.rst
    :recursive:
 
-   File
    Field
+   File
+   NXdata
+   NXdetector
+   NXdisk_chopper
+   NXentry
+   NXevent_data
+   NXinstrument
+   NXlog
+   NXmonitor
+   NXobject
    NXroot
+   NXsample
+   NXsource
+   NXtransformations
 
 Exceptions
 ----------

--- a/docs/user-guide/nexus-classes.ipynb
+++ b/docs/user-guide/nexus-classes.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "444ce621-fecd-4a30-ba53-15bb9c87bd96",
+   "id": "04343de9-cb0d-44ae-a1a8-a107da63a8ff",
    "metadata": {
     "tags": []
    },
@@ -16,28 +16,13 @@
     "Furthermore, not all features of each class definition are implemented.\n",
     "The class of a group is read from the group's `'NX_class'` attribute.\n",
     "\n",
-    "We give an overview of supported classes in the following.\n",
-    "There are roughly two categories of classes, those that contain data and can be read as a `scipp.DataArray` (for example NXdata), and those that mostly serve as groups for nested classes (for example NXentry containing NXdata).\n",
-    "\n",
-    "We use a file from the scippnexus sample data:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "62027f15-d168-40fd-a8eb-39ac62d2b4ff",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "from scippnexus import data\n",
-    "filename = data.get_path('PG3_4844_event.nxs')\n",
-    "import scippnexus as snx\n",
-    "f = snx.File(filename)"
+    "The following table gives an overview of supported classes.\n",
+    "There are roughly two categories of classes, those that contain data and can be read as a `scipp.DataArray` (for example NXdata), and those that mostly serve as groups for nested classes (for example NXentry containing NXdata):"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "f59eda25-466c-4437-a7b4-825cb036232c",
+   "id": "3915e79e-1cc8-4db6-abb6-851290e3c018",
    "metadata": {},
    "source": [
     "NeXus class | read as | comment | NeXus specification\n",
@@ -54,6 +39,29 @@
     "[NXsample](../generated/classes/scippnexus.NXsample.rst) | scipp.Dataset |very incomplete support| [link](https://manual.nexusformat.org/classes/base_classes/NXsample.html)\n",
     "[NXsource](../generated/classes/scippnexus.NXsource.rst) | scipp.Dataset |very incomplete support| [link](https://manual.nexusformat.org/classes/base_classes/NXsource.html)\n",
     "[NXtransformations](../generated/classes/scippnexus.NXtransformations.rst) | &mdash; | [generic group-like](#Base-class:-NXobject) | [link](https://manual.nexusformat.org/classes/base_classes/NXtransformations.html)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "65b08827-a74f-440f-9eda-0747d6d5e007",
+   "metadata": {
+    "tags": []
+   },
+   "source": [
+    "For the examples below we use a file from the scippnexus sample data:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "62027f15-d168-40fd-a8eb-39ac62d2b4ff",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from scippnexus import data\n",
+    "filename = data.get_path('PG3_4844_event.nxs')\n",
+    "import scippnexus as snx\n",
+    "f = snx.File(filename)"
    ]
   },
   {

--- a/docs/user-guide/nexus-classes.ipynb
+++ b/docs/user-guide/nexus-classes.ipynb
@@ -42,11 +42,18 @@
    "source": [
     "NeXus class | read as | comment | NeXus<br/>specification\n",
     ":--- |:--- |:--- |:---\n",
+    "[NXdata](generated/classes/scippnexus.NXdata.html) | scipp.DataArray | [example below](#NXdata) | [link](https://manual.nexusformat.org/classes/base_classes/NXdata.html)\n",
+    "[NXdetector](generated/classes/scippnexus.NXdetector.html) | scipp.DataArray | [example below](#NXdetector) | [link](https://manual.nexusformat.org/classes/base_classes/NXdetector.html)\n",
+    "[NXdisk_chopper](generated/classes/scippnexus.NXdisk_chopper.html) | scipp.Dataset |very incomplete support| [link](https://manual.nexusformat.org/classes/base_classes/NXdisk_chopper.html)\n",
+    "[NXentry](generated/classes/scippnexus.NXentry.html) | - | [generic group-like](#Base-class:-NXobject) | [link](https://manual.nexusformat.org/classes/base_classes/NXentry.html)\n",
+    "[NXevent_data](generated/classes/scippnexus.NXevent_data.html) | scipp.DataArray | [example below](#NXevent_data) | [link](https://manual.nexusformat.org/classes/base_classes/NXevent_data.html)\n",
+    "[NXinstrument](generated/classes/scippnexus.NXinstrument.html) | - | [generic group-like](#Base-class:-NXobject) | [link](https://manual.nexusformat.org/classes/base_classes/NXinstrument.html)\n",
+    "[NXlog](generated/classes/scippnexus.NXlog.html) | scipp.DataArray | [example below](#NXlog) | [link](https://manual.nexusformat.org/classes/base_classes/NXlog.html)\n",
+    "[NXmonitor](generated/classes/scippnexus.NXmonitor.html) | scipp.DataArray | [example below](#NXmonitor) | [link](https://manual.nexusformat.org/classes/base_classes/NXmonitor.html)\n",
     "[NXroot](generated/classes/scippnexus.NXroot.html) | - | [generic group-like](#Base-class:-NXobject) | [link](https://manual.nexusformat.org/classes/base_classes/NXroot.html)\n",
-    "[NXdata](generated/classes/scippnexus.NXroot.html) | scipp.DataArray | [example below](#NXdata) | [link](https://manual.nexusformat.org/classes/base_classes/NXdata.html)\n",
-    "NXsample | scipp.Dataset |very incomplete support| [link](https://manual.nexusformat.org/classes/base_classes/NXsample.html)\n",
-    "NXsource | scipp.Dataset |very incomplete support| [link](https://manual.nexusformat.org/classes/base_classes/NXsource.html)\n",
-    "NXtransformations | - | | [link](https://manual.nexusformat.org/classes/base_classes/NXtransformations.html)"
+    "[NXsample](generated/classes/scippnexus.NXsample.html) | scipp.Dataset |very incomplete support| [link](https://manual.nexusformat.org/classes/base_classes/NXsample.html)\n",
+    "[NXsource](generated/classes/scippnexus.NXsource.html) | scipp.Dataset |very incomplete support| [link](https://manual.nexusformat.org/classes/base_classes/NXsource.html)\n",
+    "[NXtransformations](generated/classes/scippnexus.NXtransformations.html) | - | [generic group-like](#Base-class:-NXobject) | [link](https://manual.nexusformat.org/classes/base_classes/NXtransformations.html)"
    ]
   },
   {

--- a/docs/user-guide/nexus-classes.ipynb
+++ b/docs/user-guide/nexus-classes.ipynb
@@ -44,7 +44,8 @@
    "source": [
     "## NXdata\n",
     "\n",
-    "[NXdata](https://manual.nexusformat.org/classes/base_classes/NXdata.html) provides multi-dimensional labeled data.\n",
+    "Provides multi-dimensional labeled data.\n",
+    "See the NeXus format [NXdata base class definition](https://manual.nexusformat.org/classes/base_classes/NXdata.html) for details.\n",
     "Can be read as a data array using slicing syntax.\n",
     "\n",
     "Example:"
@@ -80,7 +81,8 @@
    "source": [
     "## NXdetector\n",
     "\n",
-    "[NXdetector](https://manual.nexusformat.org/classes/base_classes/NXdetector.html) provides data for detector.\n",
+    "Provides data for a detector.\n",
+    "See the NeXus format [NXdetector base class definition](https://manual.nexusformat.org/classes/base_classes/NXdetector.html) for details.\n",
     "Can be read as a data array using slicing syntax.\n",
     "The underlying data may be dense data or event data.\n",
     "\n",
@@ -151,7 +153,8 @@
    "source": [
     "## NXdisk_chopper\n",
     "\n",
-    "[NXdisk_chopper](https://manual.nexusformat.org/classes/base_classes/NXdisk_chopper.html) provides information about a disk chopper.\n",
+    "Provides information about a disk chopper.\n",
+    "See the NeXus format [NXdisk_chopper base class definition](https://manual.nexusformat.org/classes/base_classes/NXdisk_chopper.html) for details.\n",
     "Can be read as a dataset using slicing syntax.\n",
     "Currently only `distance` and `rotation_speed` fields are loaded."
    ]
@@ -165,7 +168,8 @@
    "source": [
     "## NXentry\n",
     "\n",
-    "An [NXentry](https://manual.nexusformat.org/classes/base_classes/NXentry.html) is contained in NXroot.\n",
+    "An entry is contained in NXroot and groups other information.\n",
+    "See the NeXus format [NXentry base class definition](https://manual.nexusformat.org/classes/base_classes/NXentry.html) for details.\n",
     "Currently no support for features apart from generic group-like interface.\n",
     "\n",
     "Example:"
@@ -191,7 +195,8 @@
    "source": [
     "## NXevent_data\n",
     "\n",
-    "[NXevent_data](https://manual.nexusformat.org/classes/base_classes/NXevent_data.html) provides event data in raw format as produced by the acquisition system, i.e., not grouped into detector pixels.\n",
+    "Provides event data in raw format as produced by the acquisition system, i.e., not grouped into detector pixels.\n",
+    "See the NeXus format [NXevent_data base class definition](https://manual.nexusformat.org/classes/base_classes/NXevent_data.html) for details.\n",
     "Can be read as a data array using slicing syntax.\n",
     "\n",
     "Example:"
@@ -236,7 +241,8 @@
    "source": [
     "## NXinstrument\n",
     "\n",
-    "[NXinstrument](https://manual.nexusformat.org/classes/base_classes/NXinstrument.html) groups other information such as detectors.\n",
+    "Groups other information such as detectors.\n",
+    "See the NeXus format [NXinstrument base class definition](https://manual.nexusformat.org/classes/base_classes/NXinstrument.html) for details.\n",
     "Currently no support for features apart from generic group-like interface.\n",
     "\n",
     "Example:"
@@ -262,7 +268,8 @@
    "source": [
     "## NXlog\n",
     "\n",
-    "[NXlog](https://manual.nexusformat.org/classes/base_classes/NXlog.html) provides time-series logs.\n",
+    "Provides a  time-series log.\n",
+    "See the NeXus format [NXlog base class definition](https://manual.nexusformat.org/classes/base_classes/NXlog.html) for details.\n",
     "Can be read as a data array using slicing syntax.\n",
     "\n",
     "Example:"
@@ -298,7 +305,8 @@
    "source": [
     "## NXmonitor\n",
     "\n",
-    "[NXmonitor](https://manual.nexusformat.org/classes/base_classes/NXmonitor.html) provides data for beam monitors.\n",
+    "Provides data for a beam monitor.\n",
+    "See the NeXus format [NXmonitor base class definition](https://manual.nexusformat.org/classes/base_classes/NXmonitor.html) for details.\n",
     "Can be read as a data array using slicing syntax.\n",
     "\n",
     "Example:"
@@ -324,7 +332,8 @@
    "source": [
     "## NXroot\n",
     "\n",
-    "[NXroot](https://manual.nexusformat.org/classes/base_classes/NXroot.html) is used for the root group, i.e., the file.\n",
+    "The root group, i.e., the file.\n",
+    "See the NeXus format [NXroot base class definition](https://manual.nexusformat.org/classes/base_classes/NXroot.html) for details.\n",
     "Currently no support for features apart from generic group-like interface.\n",
     "\n",
     "Example:"
@@ -359,7 +368,8 @@
    "source": [
     "## NXsample\n",
     "\n",
-    "[NXsample](https://manual.nexusformat.org/classes/base_classes/NXsample.html) provides information about a disk chopper.\n",
+    "Provides information about a sample.\n",
+    "See the NeXus format [NXsample base class definition](https://manual.nexusformat.org/classes/base_classes/NXsample.html) for details.\n",
     "Can be read as a dataset using slicing syntax.\n",
     "Currently only `distance`, `orientation_matrix`, and `ub_matrix` fields are loaded.\n",
     "\n",
@@ -386,7 +396,8 @@
    "source": [
     "## NXsource\n",
     "\n",
-    "[NXsource](https://manual.nexusformat.org/classes/base_classes/NXsource.html) provides information about the source.\n",
+    "Provides information about the source.\n",
+    "See the NeXus format [NXsource base class definition](https://manual.nexusformat.org/classes/base_classes/NXsource.html) for details.\n",
     "Can be read as a dataset using slicing syntax.\n",
     "Currently only the `distance` field is loaded.\n",
     "\n",
@@ -413,7 +424,8 @@
    "source": [
     "## NXtransformations\n",
     "\n",
-    "[NXtransformations](https://manual.nexusformat.org/classes/base_classes/NXtransformations.html) groups spatial transformations.\n",
+    "Groups spatial transformations.\n",
+    "See the NeXus format [NXtransformations base class definition](https://manual.nexusformat.org/classes/base_classes/NXtransformations.html) for details.\n",
     "Currently no support for features apart from generic group-like interface."
    ]
   }

--- a/docs/user-guide/nexus-classes.ipynb
+++ b/docs/user-guide/nexus-classes.ipynb
@@ -40,20 +40,20 @@
    "id": "f59eda25-466c-4437-a7b4-825cb036232c",
    "metadata": {},
    "source": [
-    "NeXus class | read as | comment | NeXus<br/>specification\n",
+    "NeXus class | read as | comment | NeXus specification\n",
     ":--- |:--- |:--- |:---\n",
-    "[NXdata](generated/classes/scippnexus.NXdata.html) | scipp.DataArray | [example below](#NXdata) | [link](https://manual.nexusformat.org/classes/base_classes/NXdata.html)\n",
-    "[NXdetector](generated/classes/scippnexus.NXdetector.html) | scipp.DataArray | [example below](#NXdetector) | [link](https://manual.nexusformat.org/classes/base_classes/NXdetector.html)\n",
-    "[NXdisk_chopper](generated/classes/scippnexus.NXdisk_chopper.html) | scipp.Dataset |very incomplete support| [link](https://manual.nexusformat.org/classes/base_classes/NXdisk_chopper.html)\n",
-    "[NXentry](generated/classes/scippnexus.NXentry.html) | - | [generic group-like](#Base-class:-NXobject) | [link](https://manual.nexusformat.org/classes/base_classes/NXentry.html)\n",
-    "[NXevent_data](generated/classes/scippnexus.NXevent_data.html) | scipp.DataArray | [example below](#NXevent_data) | [link](https://manual.nexusformat.org/classes/base_classes/NXevent_data.html)\n",
-    "[NXinstrument](generated/classes/scippnexus.NXinstrument.html) | - | [generic group-like](#Base-class:-NXobject) | [link](https://manual.nexusformat.org/classes/base_classes/NXinstrument.html)\n",
-    "[NXlog](generated/classes/scippnexus.NXlog.html) | scipp.DataArray | [example below](#NXlog) | [link](https://manual.nexusformat.org/classes/base_classes/NXlog.html)\n",
-    "[NXmonitor](generated/classes/scippnexus.NXmonitor.html) | scipp.DataArray | [example below](#NXmonitor) | [link](https://manual.nexusformat.org/classes/base_classes/NXmonitor.html)\n",
-    "[NXroot](generated/classes/scippnexus.NXroot.html) | - | [generic group-like](#Base-class:-NXobject) | [link](https://manual.nexusformat.org/classes/base_classes/NXroot.html)\n",
-    "[NXsample](generated/classes/scippnexus.NXsample.html) | scipp.Dataset |very incomplete support| [link](https://manual.nexusformat.org/classes/base_classes/NXsample.html)\n",
-    "[NXsource](generated/classes/scippnexus.NXsource.html) | scipp.Dataset |very incomplete support| [link](https://manual.nexusformat.org/classes/base_classes/NXsource.html)\n",
-    "[NXtransformations](generated/classes/scippnexus.NXtransformations.html) | - | [generic group-like](#Base-class:-NXobject) | [link](https://manual.nexusformat.org/classes/base_classes/NXtransformations.html)"
+    "[NXdata](../generated/classes/scippnexus.NXdata.rst) | scipp.DataArray | [example below](#NXdata) | [link](https://manual.nexusformat.org/classes/base_classes/NXdata.html)\n",
+    "[NXdetector](../generated/classes/scippnexus.NXdetector.rst) | scipp.DataArray | [example below](#NXdetector) | [link](https://manual.nexusformat.org/classes/base_classes/NXdetector.html)\n",
+    "[NXdisk_chopper](../generated/classes/scippnexus.NXdisk_chopper.rst) | scipp.Dataset |very incomplete support| [link](https://manual.nexusformat.org/classes/base_classes/NXdisk_chopper.html)\n",
+    "[NXentry](../generated/classes/scippnexus.NXentry.rst) | &mdash; | [generic group-like](#Base-class:-NXobject) | [link](https://manual.nexusformat.org/classes/base_classes/NXentry.html)\n",
+    "[NXevent_data](../generated/classes/scippnexus.NXevent_data.rst) | scipp.DataArray | [example below](#NXevent_data) | [link](https://manual.nexusformat.org/classes/base_classes/NXevent_data.html)\n",
+    "[NXinstrument](../generated/classes/scippnexus.NXinstrument.rst) | &mdash; | [generic group-like](#Base-class:-NXobject) | [link](https://manual.nexusformat.org/classes/base_classes/NXinstrument.html)\n",
+    "[NXlog](../generated/classes/scippnexus.NXlog.rst) | scipp.DataArray | [example below](#NXlog) | [link](https://manual.nexusformat.org/classes/base_classes/NXlog.html)\n",
+    "[NXmonitor](../generated/classes/scippnexus.NXmonitor.rst) | scipp.DataArray | [example below](#NXmonitor) | [link](https://manual.nexusformat.org/classes/base_classes/NXmonitor.html)\n",
+    "[NXroot](../generated/classes/scippnexus.NXroot.rst) | &mdash; | [generic group-like](#Base-class:-NXobject) | [link](https://manual.nexusformat.org/classes/base_classes/NXroot.html)\n",
+    "[NXsample](../generated/classes/scippnexus.NXsample.rst) | scipp.Dataset |very incomplete support| [link](https://manual.nexusformat.org/classes/base_classes/NXsample.html)\n",
+    "[NXsource](../generated/classes/scippnexus.NXsource.rst) | scipp.Dataset |very incomplete support| [link](https://manual.nexusformat.org/classes/base_classes/NXsource.html)\n",
+    "[NXtransformations](../generated/classes/scippnexus.NXtransformations.rst) | &mdash; | [generic group-like](#Base-class:-NXobject) | [link](https://manual.nexusformat.org/classes/base_classes/NXtransformations.html)"
    ]
   },
   {

--- a/docs/user-guide/nexus-classes.ipynb
+++ b/docs/user-guide/nexus-classes.ipynb
@@ -1,0 +1,442 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "444ce621-fecd-4a30-ba53-15bb9c87bd96",
+   "metadata": {
+    "tags": []
+   },
+   "source": [
+    "# NeXus classes\n",
+    "\n",
+    "## Overview\n",
+    "\n",
+    "NeXus provides a substantial number of [base class definitions](https://manual.nexusformat.org/classes/base_classes/index.html#base-class-definitions).\n",
+    "At this point scippnexus supports only a very limited number of these.\n",
+    "Furthermore, not all features of each class definition are implemented.\n",
+    "The class of a group is read from the group's `'NX_class'` attribute.\n",
+    "\n",
+    "We give an overview of supported classes in the following.\n",
+    "There are roughly two categories of classes, those that contain data and can be read as a `scipp.DataArray` (for example NXdata), and those that mostly serve as groups for nested classes (for example NXentry containing NXdata).\n",
+    "\n",
+    "We use a file from the scippnexus sample data:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "62027f15-d168-40fd-a8eb-39ac62d2b4ff",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from scippnexus import data\n",
+    "filename = data.get_path('PG3_4844_event.nxs')\n",
+    "import scippnexus as snx\n",
+    "f = snx.File(filename)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "e42c2ca4-d57a-46aa-9a81-69d490f8177e",
+   "metadata": {
+    "tags": []
+   },
+   "source": [
+    "## NXdata\n",
+    "\n",
+    "[NXdata](https://manual.nexusformat.org/classes/base_classes/NXdata.html) provides multi-dimensional labeled data.\n",
+    "Can be read as a data array using slicing syntax.\n",
+    "\n",
+    "Example:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "39f734ff-3c8c-4bb7-92c3-144592e2b8aa",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "data = f['entry/bank103']\n",
+    "data"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "2e769939-daeb-483b-95e6-9b5d841c1a65",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "data['x_pixel_offset', :10]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "40878042-4991-484c-b605-56aed188b7ca",
+   "metadata": {
+    "tags": []
+   },
+   "source": [
+    "## NXdetector\n",
+    "\n",
+    "[NXdetector](https://manual.nexusformat.org/classes/base_classes/NXdetector.html) provides data for detector.\n",
+    "Can be read as a data array using slicing syntax.\n",
+    "The underlying data may be dense data or event data.\n",
+    "\n",
+    "Example:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "000a8f9b-1ed4-452e-a870-54457056698d",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "detector = f['entry/instrument/bank102']\n",
+    "detector"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "0d97df83-09f1-4c03-a782-7a67a5792286",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "detector[...]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "de532afe-6382-420b-bda4-4297172ffec5",
+   "metadata": {},
+   "source": [
+    "If the underlying data is event data, the underlying event data can be selected using the special `select_events` property.\n",
+    "For example, we can select the first 1000 pulses and load data for all pixels:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "25b20528-63bb-46a2-b4bf-2106b5ae9ab1",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "detector.select_events['pulse', :1000][...]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a17cf9bf-fe20-4d51-87c9-63ad660efa67",
+   "metadata": {},
+   "source": [
+    "<div class=\"alert alert-info\">\n",
+    "    <b>Note:</b>\n",
+    "\n",
+    "Selecting a range of events allows for loading only a potentially very small section of the underlying event data and can thus be very fast.\n",
+    "\n",
+    "In contrast, e.g., selecting a small range of pixels in presence of underlying event data is *not* fast, since the events for all pixels are stored in the order as they arrive in the acquisition system and the entire [NXevent_data](#NXevent_data) group must be loaded.\n",
+    "\n",
+    "</div>"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "cfc159d9-3d90-4735-a59d-f968e1b5626a",
+   "metadata": {
+    "tags": []
+   },
+   "source": [
+    "## NXdisk_chopper\n",
+    "\n",
+    "[NXdisk_chopper](https://manual.nexusformat.org/classes/base_classes/NXdisk_chopper.html) provides information about a disk chopper.\n",
+    "Can be read as a dataset using slicing syntax.\n",
+    "Currently only `distance` and `rotation_speed` fields are loaded."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "3a2e6158-810f-4e70-970f-ceec2bbab8dd",
+   "metadata": {
+    "tags": []
+   },
+   "source": [
+    "## NXentry\n",
+    "\n",
+    "An [NXentry](https://manual.nexusformat.org/classes/base_classes/NXentry.html) is contained in NXroot.\n",
+    "Currently no support for features apart from generic group-like interface.\n",
+    "\n",
+    "Example:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "8560a474-61a7-40c8-bd94-ad3a1d8227d9",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "entry = f['entry']\n",
+    "entry"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "1c693f90-f9f1-4476-9a6e-48c4593dc637",
+   "metadata": {
+    "tags": []
+   },
+   "source": [
+    "## NXevent_data\n",
+    "\n",
+    "[NXevent_data](https://manual.nexusformat.org/classes/base_classes/NXevent_data.html) provides event data in raw format as produced by the acquisition system, i.e., not grouped into detector pixels.\n",
+    "Can be read as a data array using slicing syntax.\n",
+    "\n",
+    "Example:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "76f0ee9d-4c39-43a1-a1f2-d60c87a30718",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "event_data = f['entry/bank102_events']\n",
+    "event_data[...]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "951eaedb-21bc-459b-b68f-ff832b751057",
+   "metadata": {},
+   "source": [
+    "In some cases the event data fields may be contained directly within an [NXdetector](#NXdetector).\n",
+    "The event data can also be accessed from there:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "36730d49-56e8-45a1-9071-1827050daf18",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "f['entry/instrument/bank102'].events[...]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "eb2603b0-f721-4c9f-a848-d2b85fd57923",
+   "metadata": {
+    "tags": []
+   },
+   "source": [
+    "## NXinstrument\n",
+    "\n",
+    "[NXinstrument](https://manual.nexusformat.org/classes/base_classes/NXinstrument.html) groups other information such as detectors.\n",
+    "Currently no support for features apart from generic group-like interface.\n",
+    "\n",
+    "Example:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "e75f8cfa-2e9a-490d-9ba1-8ca69df74ad9",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "instrument = f['entry/instrument']\n",
+    "instrument"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a2a7f817-0b47-47ba-9da7-bcd19819b087",
+   "metadata": {
+    "tags": []
+   },
+   "source": [
+    "## NXlog\n",
+    "\n",
+    "[NXlog](https://manual.nexusformat.org/classes/base_classes/NXlog.html) provides time-series logs.\n",
+    "Can be read as a data array using slicing syntax.\n",
+    "\n",
+    "Example:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "fc09c271-ca12-4fd4-b219-2f382a6c3b6a",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "proton_charge = f['/entry/DASlogs/proton_charge']\n",
+    "proton_charge"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "766d4de3-f5bb-4b57-8ab2-1cc1b9a05599",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "proton_charge[...]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "0f2d35af-aa81-4772-a2c6-7bd4aebff34e",
+   "metadata": {
+    "tags": []
+   },
+   "source": [
+    "## NXmonitor\n",
+    "\n",
+    "[NXmonitor](https://manual.nexusformat.org/classes/base_classes/NXmonitor.html) provides data for beam monitors.\n",
+    "Can be read as a data array using slicing syntax.\n",
+    "\n",
+    "Example:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "1c0aed53-1734-4090-9312-994c53f600e9",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "monitor = f['entry/monitor1']\n",
+    "monitor[...]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "54f958a1-5cb7-49cc-a907-194c68d6daa3",
+   "metadata": {
+    "tags": []
+   },
+   "source": [
+    "## NXroot\n",
+    "\n",
+    "[NXroot](https://manual.nexusformat.org/classes/base_classes/NXroot.html) is used for the root group, i.e., the file.\n",
+    "Currently no support for features apart from generic group-like interface.\n",
+    "\n",
+    "Example:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "e0c03587-013d-4961-88ee-3ceeb4e1c71b",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "f.nx_class"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "708c55e0-b55d-47a5-9585-7b2db42bdeff",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "list(f.keys())"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "1e9030f1-1e42-41c5-9a6a-3d431573513c",
+   "metadata": {
+    "tags": []
+   },
+   "source": [
+    "## NXsample\n",
+    "\n",
+    "[NXsample](https://manual.nexusformat.org/classes/base_classes/NXsample.html) provides information about a disk chopper.\n",
+    "Can be read as a dataset using slicing syntax.\n",
+    "Currently only `distance`, `orientation_matrix`, and `ub_matrix` fields are loaded.\n",
+    "\n",
+    "Example:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "9313e63a-1e0f-43cd-a325-a9bf1c2d1cef",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "sample = f['/entry/sample']\n",
+    "sample"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "f8506b6a-59e5-4853-8c69-93e553e97dc1",
+   "metadata": {
+    "tags": []
+   },
+   "source": [
+    "## NXsource\n",
+    "\n",
+    "[NXsource](https://manual.nexusformat.org/classes/base_classes/NXsource.html) provides information about the source.\n",
+    "Can be read as a dataset using slicing syntax.\n",
+    "Currently only the `distance` field is loaded.\n",
+    "\n",
+    "Example:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "b6b2448d-5047-4197-b0a3-a516750d7200",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "source = f['/entry/instrument/SNS']\n",
+    "source"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "82d61cdc-7e46-443e-8898-6fd2c9cf7861",
+   "metadata": {
+    "tags": []
+   },
+   "source": [
+    "## NXtransformations\n",
+    "\n",
+    "[NXtransformations](https://manual.nexusformat.org/classes/base_classes/NXtransformations.html) groups spatial transformations.\n",
+    "Currently no support for features apart from generic group-like interface."
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.8.12"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/docs/user-guide/nexus-classes.ipynb
+++ b/docs/user-guide/nexus-classes.ipynb
@@ -37,6 +37,36 @@
   },
   {
    "cell_type": "markdown",
+   "id": "f59eda25-466c-4437-a7b4-825cb036232c",
+   "metadata": {},
+   "source": [
+    "NeXus class | read as | comment | NeXus<br/>specification\n",
+    ":--- |:--- |:--- |:---\n",
+    "[NXroot](generated/classes/scippnexus.NXroot.html) | - | [generic group-like](#Base-class:-NXobject) | [link](https://manual.nexusformat.org/classes/base_classes/NXroot.html)\n",
+    "[NXdata](generated/classes/scippnexus.NXroot.html) | scipp.DataArray | [example below](#NXdata) | [link](https://manual.nexusformat.org/classes/base_classes/NXdata.html)\n",
+    "NXsample | scipp.Dataset |very incomplete support| [link](https://manual.nexusformat.org/classes/base_classes/NXsample.html)\n",
+    "NXsource | scipp.Dataset |very incomplete support| [link](https://manual.nexusformat.org/classes/base_classes/NXsource.html)\n",
+    "NXtransformations | - | | [link](https://manual.nexusformat.org/classes/base_classes/NXtransformations.html)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "32c5c15c-e8bd-41fb-9379-e678389c7f38",
+   "metadata": {
+    "tags": []
+   },
+   "source": [
+    "## Base class: NXobject\n",
+    "\n",
+    "Base of all other NeXus classes.\n",
+    "Provides a generic group-like interface.\n",
+    "That is, this is equivalent to a dictionary of fields and/or other groups.\n",
+    "\n",
+    "NeXus classes that group other information but cannot be read as a data array or dataset provide this interface."
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "e42c2ca4-d57a-46aa-9a81-69d490f8177e",
    "metadata": {
     "tags": []

--- a/docs/user-guide/nexus-classes.ipynb
+++ b/docs/user-guide/nexus-classes.ipynb
@@ -433,8 +433,7 @@
    "mimetype": "text/x-python",
    "name": "python",
    "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython3",
-   "version": "3.8.12"
+   "pygments_lexer": "ipython3"
   }
  },
  "nbformat": 4,

--- a/docs/user-guide/nexus-classes.ipynb
+++ b/docs/user-guide/nexus-classes.ipynb
@@ -183,48 +183,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "cfc159d9-3d90-4735-a59d-f968e1b5626a",
-   "metadata": {
-    "tags": []
-   },
-   "source": [
-    "## NXdisk_chopper\n",
-    "\n",
-    "Provides information about a disk chopper.\n",
-    "See the NeXus format [NXdisk_chopper base class definition](https://manual.nexusformat.org/classes/base_classes/NXdisk_chopper.html) for details.\n",
-    "Can be read as a dataset using slicing syntax.\n",
-    "Currently only `distance` and `rotation_speed` fields are loaded."
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "3a2e6158-810f-4e70-970f-ceec2bbab8dd",
-   "metadata": {
-    "tags": []
-   },
-   "source": [
-    "## NXentry\n",
-    "\n",
-    "An entry is contained in NXroot and groups other information.\n",
-    "See the NeXus format [NXentry base class definition](https://manual.nexusformat.org/classes/base_classes/NXentry.html) for details.\n",
-    "Currently no support for features apart from generic group-like interface.\n",
-    "\n",
-    "Example:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "8560a474-61a7-40c8-bd94-ad3a1d8227d9",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "entry = f['entry']\n",
-    "entry"
-   ]
-  },
-  {
-   "cell_type": "markdown",
    "id": "1c693f90-f9f1-4476-9a6e-48c4593dc637",
    "metadata": {
     "tags": []
@@ -267,33 +225,6 @@
    "outputs": [],
    "source": [
     "f['entry/instrument/bank102'].events[...]"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "eb2603b0-f721-4c9f-a848-d2b85fd57923",
-   "metadata": {
-    "tags": []
-   },
-   "source": [
-    "## NXinstrument\n",
-    "\n",
-    "Groups other information such as detectors.\n",
-    "See the NeXus format [NXinstrument base class definition](https://manual.nexusformat.org/classes/base_classes/NXinstrument.html) for details.\n",
-    "Currently no support for features apart from generic group-like interface.\n",
-    "\n",
-    "Example:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "e75f8cfa-2e9a-490d-9ba1-8ca69df74ad9",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "instrument = f['entry/instrument']\n",
-    "instrument"
    ]
   },
   {
@@ -358,112 +289,6 @@
    "source": [
     "monitor = f['entry/monitor1']\n",
     "monitor[...]"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "54f958a1-5cb7-49cc-a907-194c68d6daa3",
-   "metadata": {
-    "tags": []
-   },
-   "source": [
-    "## NXroot\n",
-    "\n",
-    "The root group, i.e., the file.\n",
-    "See the NeXus format [NXroot base class definition](https://manual.nexusformat.org/classes/base_classes/NXroot.html) for details.\n",
-    "Currently no support for features apart from generic group-like interface.\n",
-    "\n",
-    "Example:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "e0c03587-013d-4961-88ee-3ceeb4e1c71b",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "f.nx_class"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "708c55e0-b55d-47a5-9585-7b2db42bdeff",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "list(f.keys())"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "1e9030f1-1e42-41c5-9a6a-3d431573513c",
-   "metadata": {
-    "tags": []
-   },
-   "source": [
-    "## NXsample\n",
-    "\n",
-    "Provides information about a sample.\n",
-    "See the NeXus format [NXsample base class definition](https://manual.nexusformat.org/classes/base_classes/NXsample.html) for details.\n",
-    "Can be read as a dataset using slicing syntax.\n",
-    "Currently only `distance`, `orientation_matrix`, and `ub_matrix` fields are loaded.\n",
-    "\n",
-    "Example:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "9313e63a-1e0f-43cd-a325-a9bf1c2d1cef",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "sample = f['/entry/sample']\n",
-    "sample"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "f8506b6a-59e5-4853-8c69-93e553e97dc1",
-   "metadata": {
-    "tags": []
-   },
-   "source": [
-    "## NXsource\n",
-    "\n",
-    "Provides information about the source.\n",
-    "See the NeXus format [NXsource base class definition](https://manual.nexusformat.org/classes/base_classes/NXsource.html) for details.\n",
-    "Can be read as a dataset using slicing syntax.\n",
-    "Currently only the `distance` field is loaded.\n",
-    "\n",
-    "Example:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "b6b2448d-5047-4197-b0a3-a516750d7200",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "source = f['/entry/instrument/SNS']\n",
-    "source"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "82d61cdc-7e46-443e-8898-6fd2c9cf7861",
-   "metadata": {
-    "tags": []
-   },
-   "source": [
-    "## NXtransformations\n",
-    "\n",
-    "Groups spatial transformations.\n",
-    "See the NeXus format [NXtransformations base class definition](https://manual.nexusformat.org/classes/base_classes/NXtransformations.html) for details.\n",
-    "Currently no support for features apart from generic group-like interface."
    ]
   }
  ],

--- a/src/scippnexus/__init__.py
+++ b/src/scippnexus/__init__.py
@@ -9,7 +9,16 @@ try:
 except importlib.metadata.PackageNotFoundError:
     __version__ = "0.0.0"
 
-from .file import File
-from .nxobject import NX_class, Field, NXroot
-from .nxobject import NexusStructureError
 from . import typing
+from .file import File
+from .nxdata import NXdata
+from .nxdetector import NXdetector
+from .nxdisk_chopper import NXdisk_chopper
+from .nxevent_data import NXevent_data
+from .nxlog import NXlog
+from .nxmonitor import NXmonitor
+from .nxobject import NX_class, NXobject, Field
+from .nxobject import NXentry, NXinstrument, NXroot, NXtransformations
+from .nxobject import NexusStructureError
+from .nxsample import NXsample
+from .nxsource import NXsource

--- a/src/scippnexus/nxdata.py
+++ b/src/scippnexus/nxdata.py
@@ -20,13 +20,18 @@ class NXdata(NXobject):
             axes: List[str] = None,
             skip: List[str] = None):
         """
-        :param signal_name_default: Default signal name used, if no `signal`
-            attribute found in file.
-        :param signal_override Signal field-like to use instead of trying to read
-            signal from the file. This is used when there is no signal or to provide
-            a signal computed from NXevent_data
-        :param axes: Default axes used, if no `axes` attribute found in file.
-        :param skip: Names of fields to skip when loading coords.
+        Parameters
+        ----------
+        signal_name_default:
+            Default signal name used, if no `signal` attribute found in file.
+        signal_override:
+            Field-like to use instead of trying to read signal from the file. This is
+            used when there is no signal or to provide a signal computed from
+            NXevent_data.
+        axes:
+            Default axes used, if no `axes` attribute found in file.
+        skip:
+            Names of fields to skip when loading coords.
         """
         super().__init__(group)
         self._signal_name_default = signal_name_default

--- a/src/scippnexus/nxdisk_chopper.py
+++ b/src/scippnexus/nxdisk_chopper.py
@@ -6,7 +6,7 @@ from .nxobject import NXobject, ScippIndex
 
 
 class NXdisk_chopper(NXobject):
-    """Load disk chopper as a dataset.
+    """Disk chopper information, can be read as a dataset.
 
     Currently only the 'distance' and 'rotation_speed' fields are loaded.
     """

--- a/src/scippnexus/nxdisk_chopper.py
+++ b/src/scippnexus/nxdisk_chopper.py
@@ -6,6 +6,10 @@ from .nxobject import NXobject, ScippIndex
 
 
 class NXdisk_chopper(NXobject):
+    """Load disk chopper as a dataset.
+
+    Currently only the 'distance' and 'rotation_speed' fields are loaded.
+    """
     @property
     def shape(self):
         return []

--- a/src/scippnexus/nxobject.py
+++ b/src/scippnexus/nxobject.py
@@ -342,6 +342,7 @@ class NXobject:
 
 
 class NXroot(NXobject):
+    """Root of a NeXus file."""
     @property
     def nx_class(self) -> NX_class:
         # As an oversight in the NeXus standard and the reference implementation,
@@ -352,15 +353,15 @@ class NXroot(NXobject):
 
 
 class NXentry(NXobject):
-    pass
+    """Entry in a NeXus file."""
 
 
 class NXinstrument(NXobject):
-    pass
+    """Group of instrument-related information."""
 
 
 class NXtransformations(NXobject):
-    pass
+    """Group of transformations."""
 
 
 def _make(group) -> NXobject:

--- a/src/scippnexus/nxobject.py
+++ b/src/scippnexus/nxobject.py
@@ -212,7 +212,7 @@ class NXobject:
     def _get_child(
             self,
             name: NXobjectIndex,
-            use_field_dims: bool = False) -> Union['__class__', Field, sc.DataArray]:
+            use_field_dims: bool = False) -> Union['NXobject', Field, sc.DataArray]:
         """Get item, with flag to control whether fields dims should be inferred"""
         if name is None:
             raise KeyError("None is not a valid index")
@@ -229,7 +229,7 @@ class NXobject:
         return da
 
     def __getitem__(self,
-                    name: NXobjectIndex) -> Union['__class__', Field, sc.DataArray]:
+                    name: NXobjectIndex) -> Union['NXobject', Field, sc.DataArray]:
         return self._get_child(name, use_field_dims=True)
 
     def _getitem(self, index: ScippIndex) -> NoReturn:
@@ -242,7 +242,7 @@ class NXobject:
     def __contains__(self, name: str) -> bool:
         return name in self._group
 
-    def get(self, name: str, default=None) -> Union['__class__', Field, sc.DataArray]:
+    def get(self, name: str, default=None) -> Union['NXobject', Field, sc.DataArray]:
         return self[name] if name in self else default
 
     @property
@@ -267,14 +267,14 @@ class NXobject:
     def keys(self) -> List[str]:
         return self._group.keys()
 
-    def values(self) -> List[Union[Field, '__class__']]:
+    def values(self) -> List[Union[Field, 'NXobject']]:
         return [self[name] for name in self.keys()]
 
-    def items(self) -> List[Tuple[str, Union[Field, '__class__']]]:
+    def items(self) -> List[Tuple[str, Union[Field, 'NXobject']]]:
         return list(zip(self.keys(), self.values()))
 
     @functools.lru_cache()
-    def by_nx_class(self) -> Dict[NX_class, Dict[str, '__class__']]:
+    def by_nx_class(self) -> Dict[NX_class, Dict[str, 'NXobject']]:
         classes = {name: [] for name in _nx_class_registry()}
 
         # TODO implement visititems for NXobject and merge the two blocks

--- a/src/scippnexus/nxsample.py
+++ b/src/scippnexus/nxsample.py
@@ -10,7 +10,8 @@ from .nxobject import NXobject, ScippIndex
 class NXsample(NXobject):
     """Sample information, can be read as a dataset.
 
-    Currently only the 'distance', 'orientation_matrix', and 'ub_matrix' fields are loaded.
+    Currently only the 'distance', 'orientation_matrix', and 'ub_matrix' fields are
+    loaded.
     """
     @property
     def shape(self):

--- a/src/scippnexus/nxsample.py
+++ b/src/scippnexus/nxsample.py
@@ -8,6 +8,10 @@ from .nxobject import NXobject, ScippIndex
 
 
 class NXsample(NXobject):
+    """Sample information, can be read as a dataset.
+
+    Currently only the 'distance', 'orientation_matrix', and 'ub_matrix' fields are loaded.
+    """
     @property
     def shape(self):
         return []

--- a/src/scippnexus/nxsource.py
+++ b/src/scippnexus/nxsource.py
@@ -7,6 +7,10 @@ from .nxobject import NXobject, ScippIndex
 
 
 class NXsource(NXobject):
+    """Source information, can be read as a dataset.
+
+    Currently only the 'distance' field is loaded.
+    """
     @property
     def shape(self):
         return []


### PR DESCRIPTION
Edit: I think the long list of redundant sections (for classes that simply group other stuff) is not so useful. I think I will switch this to a table instead, linking to pages generated from docstrings, and a a couple of dedicated sections with useful information (as contained in the current branch, i.e., for NXdata, NXdetector, ...):

<img width="542" alt="image" src="https://user-images.githubusercontent.com/12912489/161678651-6d89b004-19c8-4678-bef8-520548a97585.png">
