### PR TITLE
Make squeezing mechanism consistent and generic

### DIFF
--- a/src/scippnexus/nxdata.py
+++ b/src/scippnexus/nxdata.py
@@ -162,10 +162,6 @@ class NXdata(NXobject):
                                  f"{name}_error. The latter will be ignored.")
                         stddevs = self[f'{name}{suffix}'][sel]
                         coord.variances = sc.pow(stddevs, sc.scalar(2)).values
-                # NeXus treats [] and [1] interchangeably, in general this is
-                # ill-defined, but this is the best we can do.
-                if coord.shape == [1] and da.sizes.get(coord.dim) != 1:
-                    coord = coord.squeeze()
                 da.coords[name] = coord
             except sc.DimensionError as e:
                 warn(f"Skipped load of axis {field.name} due to:\n{e}")

--- a/src/scippnexus/nxobject.py
+++ b/src/scippnexus/nxobject.py
@@ -169,10 +169,22 @@ class Field:
 
     @property
     def ndim(self) -> int:
+        """Total number of dimensions in the dataset.
+
+        See the shape property for potential differences to the value returned by the
+        underlying h5py.Dataset.ndim.
+        """
         return len(self.shape)
 
     @property
     def shape(self) -> List[int]:
+        """Shape of the field.
+
+        NeXus may use extra dimensions of length one to store data, such as shape=[1]
+        instead of shape=[]. This property returns the *squeezed* shape, dropping all
+        length-1 dimensions that are not explicitly named. The returned shape may thus
+        be different from the shape of the underlying h5py.Dataset.
+        """
         return self._shape
 
     @property
@@ -265,7 +277,7 @@ class NXobject:
     def by_nx_class(self) -> Dict[NX_class, Dict[str, '__class__']]:
         classes = {name: [] for name in _nx_class_registry()}
 
-        # TODO implement visititems for NXobject and merge the the blocks
+        # TODO implement visititems for NXobject and merge the two blocks
         def _match_nx_class(_, node):
             if not hasattr(node, 'shape'):
                 if (nx_class := node.attrs.get('NX_class')) is not None:

--- a/src/scippnexus/nxtransformations.py
+++ b/src/scippnexus/nxtransformations.py
@@ -58,7 +58,7 @@ class Transformation:
         # According to private communication with Tobias Richter, NeXus allows 0-D or
         # shape=[1] for single values. It is unclear how and if this could be
         # distinguished from a scan of length 1.
-        t = self._obj[select].squeeze() * self.vector
+        t = self._obj[select] * self.vector
         v = t if isinstance(t, sc.Variable) else t.data
         if transformation_type == 'translation':
             v = v.to(unit='m', copy=False)

--- a/tests/nexus_test.py
+++ b/tests/nexus_test.py
@@ -146,7 +146,7 @@ def test_field_properties(nxroot):
     field = nxroot['entry/events_0/event_time_offset']
     assert field.dtype == 'int64'
     assert field.name == '/entry/events_0/event_time_offset'
-    assert field.shape == (6, )
+    assert field.shape == [6]
     assert field.unit == sc.Unit('ns')
 
 

--- a/tests/nxdata_test.py
+++ b/tests/nxdata_test.py
@@ -260,3 +260,34 @@ def test_uncertainties_of_coords_are_loaded(nxroot, errors_suffix):
     data.create_field('scalar', sc.values(da.coords['scalar']))
     data.create_field(f'scalar{errors_suffix}', sc.stddevs(da.coords['scalar']))
     assert sc.identical(data[...], da)
+
+
+def test_unnamed_extra_dims_of_coords_are_squeezed(nxroot):
+    signal = sc.array(dims=['xx', 'yy'], unit='m', values=[[1.1, 2.2], [3.3, 4.4]])
+    data = nxroot.create_class('data1', NX_class.NXdata)
+    data.create_field('signal', signal)
+    data.attrs['axes'] = signal.dims
+    data.attrs['signal'] = 'signal'
+    # shape=[1]
+    data.create_field('scalar', sc.array(dims=['ignored'], values=[1.2]))
+    loaded = data[...]
+    assert sc.identical(loaded.coords['scalar'], sc.scalar(1.2))
+    assert data['scalar'].ndim == 0
+    assert data['scalar'].shape == []
+    assert sc.identical(data['scalar'][...], sc.scalar(1.2))
+
+
+def test_unnamed_extra_dims_of_multidim_coords_are_squeezed(nxroot):
+    signal = sc.array(dims=['xx'], unit='m', values=[1.1, 2.2])
+    data = nxroot.create_class('data1', NX_class.NXdata)
+    data.create_field('signal', signal)
+    data.attrs['axes'] = signal.dims
+    data.attrs['signal'] = 'signal'
+    # shape=[1,2]
+    xx = sc.array(dims=['ignored', 'xx'], values=[[1.1,2.2]])
+    data.create_field('xx', xx)
+    loaded = data[...]
+    assert sc.identical(loaded.coords['xx'], xx['ignored', 0])
+    assert data['xx'].ndim == 1
+    assert data['xx'].shape == [2]
+    assert sc.identical(data['xx'][...], xx['ignored', 0])

--- a/tests/nxdata_test.py
+++ b/tests/nxdata_test.py
@@ -284,7 +284,7 @@ def test_unnamed_extra_dims_of_multidim_coords_are_squeezed(nxroot):
     data.attrs['axes'] = signal.dims
     data.attrs['signal'] = 'signal'
     # shape=[1,2]
-    xx = sc.array(dims=['ignored', 'xx'], values=[[1.1,2.2]])
+    xx = sc.array(dims=['ignored', 'xx'], values=[[1.1, 2.2]])
     data.create_field('xx', xx)
     loaded = data[...]
     assert sc.identical(loaded.coords['xx'], xx['ignored', 0])

--- a/tests/nxdetector_test.py
+++ b/tests/nxdetector_test.py
@@ -90,7 +90,7 @@ def test_loads_event_data_mapped_to_detector_numbers_based_on_their_event_id(nxr
     detector.create_field('detector_number', detector_numbers)
     create_event_data_ids_1234(detector.create_class('events', NX_class.NXevent_data))
     assert detector.dims == ['dim_0']
-    assert detector.shape == (4, )
+    assert detector.shape == [4, ]
     loaded = detector[...]
     assert sc.identical(
         loaded.bins.size().data,
@@ -104,7 +104,7 @@ def test_loads_event_data_with_2d_detector_numbers(nxroot):
     detector.create_field('detector_number', detector_numbers_xx_yy_1234())
     create_event_data_ids_1234(detector.create_class('events', NX_class.NXevent_data))
     assert detector.dims == ['dim_0', 'dim_1']
-    assert detector.shape == (2, 2)
+    assert detector.shape == [2, 2]
     loaded = detector[...]
     assert sc.identical(
         loaded.bins.size().data,

--- a/tests/nxdetector_test.py
+++ b/tests/nxdetector_test.py
@@ -90,7 +90,9 @@ def test_loads_event_data_mapped_to_detector_numbers_based_on_their_event_id(nxr
     detector.create_field('detector_number', detector_numbers)
     create_event_data_ids_1234(detector.create_class('events', NX_class.NXevent_data))
     assert detector.dims == ['dim_0']
-    assert detector.shape == [4, ]
+    assert detector.shape == [
+        4,
+    ]
     loaded = detector[...]
     assert sc.identical(
         loaded.bins.size().data,

--- a/tests/nxdetector_test.py
+++ b/tests/nxdetector_test.py
@@ -90,9 +90,7 @@ def test_loads_event_data_mapped_to_detector_numbers_based_on_their_event_id(nxr
     detector.create_field('detector_number', detector_numbers)
     create_event_data_ids_1234(detector.create_class('events', NX_class.NXevent_data))
     assert detector.dims == ['dim_0']
-    assert detector.shape == [
-        4,
-    ]
+    assert detector.shape == [4]
     loaded = detector[...]
     assert sc.identical(
         loaded.bins.size().data,


### PR DESCRIPTION
Previously we squeezed only coords added to a data array. When accessing fields directly they returned variables of different dims. Furthermore this avoids the need for squeezing downstream in a number of cases.