### PR TITLE
Generalize datetime handling

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,3 +10,7 @@ build-backend = "setuptools.build_meta"
 [tool.pytest.ini_options]
 addopts = "-ra -v"
 testpaths = "tests"
+filterwarnings = [
+  "error",
+  "ignore::UserWarning",
+]

--- a/setup.cfg
+++ b/setup.cfg
@@ -17,6 +17,7 @@ package_dir =
     = src
 packages = find:
 install_requires =
+    python-dateutil
     scipp>=0.12
     h5py
 python_requires = >=3.8

--- a/setup.cfg
+++ b/setup.cfg
@@ -17,7 +17,6 @@ package_dir =
     = src
 packages = find:
 install_requires =
-    dateutil
     scipp>=0.12
     h5py
 python_requires = >=3.8

--- a/setup.cfg
+++ b/setup.cfg
@@ -17,6 +17,7 @@ package_dir =
     = src
 packages = find:
 install_requires =
+    dateutil
     scipp>=0.12
     h5py
 python_requires = >=3.8

--- a/src/scippnexus/_common.py
+++ b/src/scippnexus/_common.py
@@ -40,14 +40,12 @@ def convert_time_to_datetime64(
             1.0, unit=raw_times.unit).to(unit=start.unit)
         unit = start.unit if ratio.value < 1.0 else raw_times.unit
 
-    raw_times = raw_times.to(unit=unit, copy=False)
-
     if scaling_factor is None:
-        times = raw_times.astype(sc.DType.int64, copy=False)
+        times = raw_times
     else:
-        _scale = sc.scalar(value=scaling_factor)
-        times = (raw_times * _scale).astype(sc.DType.int64, copy=False)
-    return start.to(unit=unit, copy=False) + times
+        times = raw_times * sc.scalar(value=scaling_factor)
+    return start.to(unit=unit, copy=False) + times.to(
+        dtype=sc.DType.int64, unit=unit, copy=False)
 
 
 def _to_canonical_select(dims: List[str], select: ScippIndex) -> ScippIndex:

--- a/src/scippnexus/_common.py
+++ b/src/scippnexus/_common.py
@@ -9,7 +9,6 @@ from .typing import ScippIndex
 
 def convert_time_to_datetime64(
         raw_times: sc.Variable,
-        group_path: str,
         start: str = None,
         scaling_factor: Union[float, np.float_] = None) -> sc.Variable:
     """
@@ -25,8 +24,6 @@ def convert_time_to_datetime64(
 
     Args:
         raw_times: The raw time data from a nexus file.
-        group_path: The path within the nexus file to the log being read.
-            Used to generate warnings if loading the log fails.
         start: Optional, the start time of the log in an ISO8601
             string. If not provided, defaults to the beginning of the
             unix epoch (1970-01-01T00:00:00).
@@ -34,31 +31,14 @@ def convert_time_to_datetime64(
             time series data and the unit of the raw_times Variable. If
             not provided, defaults to 1 (a no-op scaling factor).
     """
-    try:
-        raw_times_ns = sc.to_unit(raw_times, sc.units.ns, copy=False)
-    except sc.UnitError:
-        raise sc.UnitError(
-            f"The units of time in the entry at "
-            f"'{group_path}/time{{units}}' must be convertible to seconds, "
-            f"but this cannot be done for '{raw_times.unit}'. Skipping "
-            f"loading group at '{group_path}'.")
-
-    try:
-        _start_ts = sc.scalar(value=np.datetime64(start or "1970-01-01T00:00:00"),
-                              unit=sc.units.ns,
-                              dtype=sc.DType.datetime64)
-    except ValueError:
-        raise ValueError(
-            f"The date string '{start}' in the entry at "
-            f"'{group_path}/time@start' failed to parse as an ISO8601 date. "
-            f"Skipping loading group at '{group_path}'")
+    raw_times_ns = sc.to_unit(raw_times, sc.units.ns, copy=False)
 
     if scaling_factor is None:
         times = raw_times_ns.astype(sc.DType.int64, copy=False)
     else:
         _scale = sc.scalar(value=scaling_factor)
         times = (raw_times_ns * _scale).astype(sc.DType.int64, copy=False)
-    return _start_ts + times
+    return start + times
 
 
 def _to_canonical_select(dims: List[str], select: ScippIndex) -> ScippIndex:

--- a/src/scippnexus/_common.py
+++ b/src/scippnexus/_common.py
@@ -47,7 +47,7 @@ def convert_time_to_datetime64(
     else:
         _scale = sc.scalar(value=scaling_factor)
         times = (raw_times * _scale).astype(sc.DType.int64, copy=False)
-    return start + times
+    return start.to(unit=unit, copy=False) + times
 
 
 def _to_canonical_select(dims: List[str], select: ScippIndex) -> ScippIndex:

--- a/src/scippnexus/docs/our-interpretation-of-the-nexus-format.md
+++ b/src/scippnexus/docs/our-interpretation-of-the-nexus-format.md
@@ -47,6 +47,16 @@ More concretely this means that, e.g., for loading an `NXdetector` from a NH, th
 
 If the above yields no more than one item, the group can be loaded.
 
+## Datetime fields
+
+HDF5 does not support storing date and time information such as `np.datetime64`.
+`NXlog` and `NXevent_data` specify specific attributes for fields that have to be interpreted as date and time, in particular [NXlog/time@start](https://manual.nexusformat.org/classes/base_classes/NXlog.html#nxlog-time-start-attribute) and [NXevent_data/event_time_offset@offset](https://manual.nexusformat.org/classes/base_classes/NXevent_data.html#nxevent-data-event-time-offset-field).
+No *general* definition or intention is documented in the NF, but according to TR this is nevertheless standard.
+Due to the attribute naming mismatch in the two cases where it *is* specified we need to assume that naming is arbitrary.
+Therefore, we search *all* attributes of a field for a date and time offset, provided that the field's unit is a time unit.
+It is unclear what should be done in the case of multiple matches.
+As of April 2022 we ignore the offset in this case, since guessing which one to use based on the attribute name does not seem desirable.
+
 ## Bin edges
 
 For [NXdetector](https://manual.nexusformat.org/classes/base_classes/NXdetector.html) the NF defines a [time_of_flight](https://manual.nexusformat.org/classes/base_classes/NXdetector.html#nxdetector-time-of-flight-field) field, exceeding the data shape by one, i.e., it is meant as bin-edges.

--- a/src/scippnexus/docs/our-interpretation-of-the-nexus-format.md
+++ b/src/scippnexus/docs/our-interpretation-of-the-nexus-format.md
@@ -55,7 +55,7 @@ No *general* definition or intention is documented in the NF, but according to T
 Due to the attribute naming mismatch in the two cases where it *is* specified we need to assume that naming is arbitrary.
 Therefore, we search *all* attributes of a field for a date and time offset, provided that the field's unit is a time unit.
 It is unclear what should be done in the case of multiple matches.
-As of April 2022 we ignore the offset in this case, since guessing which one to use based on the attribute name does not seem desirable.
+As of April 2022 we ignore the date and time offsets in this case, since guessing which one to use based on the attribute name does not seem desirable.
 
 ## Bin edges
 

--- a/src/scippnexus/nxevent_data.py
+++ b/src/scippnexus/nxevent_data.py
@@ -5,7 +5,7 @@ from typing import List, Union
 import numpy as np
 import scipp as sc
 
-from ._common import to_plain_index, convert_time_to_datetime64
+from ._common import to_plain_index
 from .nxobject import NXobject, ScippIndex, NexusStructureError
 
 _event_dimension = "event"
@@ -57,11 +57,7 @@ class NXevent_data(NXobject):
             index = slice(start, stop, stride)
 
         event_index = self['event_index'][index].values
-        event_time_zero = self['event_time_zero']
-        event_time_zero = convert_time_to_datetime64(
-            event_time_zero[index],
-            start=event_time_zero.attrs.get('offset'),
-            group_path=self.name)
+        event_time_zero = self['event_time_zero'][index]
 
         num_event = self["event_time_offset"].shape[0]
         # Some files contain uint64 "max" indices, which turn into negatives during

--- a/src/scippnexus/nxlog.py
+++ b/src/scippnexus/nxlog.py
@@ -4,7 +4,6 @@
 
 from typing import List, Union
 import scipp as sc
-from ._common import convert_time_to_datetime64
 from .nxobject import NXobject, ScippIndex
 from .nxdata import NXdata
 

--- a/src/scippnexus/nxlog.py
+++ b/src/scippnexus/nxlog.py
@@ -35,20 +35,11 @@ class NXlog(NXobject):
         return NXdata(self._group, signal_name_default='value', axes=axes)
 
     def _getitem(self, select: ScippIndex) -> sc.DataArray:
-        data = self._nxbase[select]
-        # The 'time' field in NXlog contains extra properties 'start' and
-        # 'scaling_factor' that are not handled by NXdata. These are used
-        # to transform to a datetime-coord.
-        #if 'time' in self:
-        #    if 'time' not in data.coords:
-        #        raise sc.DimensionError(
-        #            "NXlog is time-dependent, but failed to load `time` dataset")
-        #    data.coords['time'] = convert_time_to_datetime64(
-        #        raw_times=data.coords.pop('time'),
-        #        start=self['time'].attrs.get('start'),
-        #        scaling_factor=self['time'].attrs.get('scaling_factor'),
-        #        group_path=self['time'].name)
-        return data
+        base = self._nxbase
+        # Field loads datetime offset attributes automatically, but for NXlog this
+        # may apparently be omitted and must then interpreted as relative to epoch.
+        base.child_params['time'] = {'is_time': True}
+        return base[select]
 
     def _get_field_dims(self, name: str) -> Union[None, List[str]]:
         return self._nxbase._get_field_dims(name)

--- a/src/scippnexus/nxlog.py
+++ b/src/scippnexus/nxlog.py
@@ -39,15 +39,15 @@ class NXlog(NXobject):
         # The 'time' field in NXlog contains extra properties 'start' and
         # 'scaling_factor' that are not handled by NXdata. These are used
         # to transform to a datetime-coord.
-        if 'time' in self:
-            if 'time' not in data.coords:
-                raise sc.DimensionError(
-                    "NXlog is time-dependent, but failed to load `time` dataset")
-            data.coords['time'] = convert_time_to_datetime64(
-                raw_times=data.coords.pop('time'),
-                start=self['time'].attrs.get('start'),
-                scaling_factor=self['time'].attrs.get('scaling_factor'),
-                group_path=self['time'].name)
+        #if 'time' in self:
+        #    if 'time' not in data.coords:
+        #        raise sc.DimensionError(
+        #            "NXlog is time-dependent, but failed to load `time` dataset")
+        #    data.coords['time'] = convert_time_to_datetime64(
+        #        raw_times=data.coords.pop('time'),
+        #        start=self['time'].attrs.get('start'),
+        #        scaling_factor=self['time'].attrs.get('scaling_factor'),
+        #        group_path=self['time'].name)
         return data
 
     def _get_field_dims(self, name: str) -> Union[None, List[str]]:

--- a/src/scippnexus/nxobject.py
+++ b/src/scippnexus/nxobject.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import re
 import warnings
 import datetime
-import dateutil
+import dateutil.parser
 from enum import Enum, auto
 import functools
 from typing import List, Union, NoReturn, Any, Dict, Tuple, Protocol

--- a/src/scippnexus/nxobject.py
+++ b/src/scippnexus/nxobject.py
@@ -116,7 +116,7 @@ def _as_datetime(obj: Any):
             # nanosecond precision.
             if 'T' in obj:
                 date, time = obj.split('T')
-                time = re.split('Z|\+|-', time)[0]
+                time = re.split(f'Z|{re.escape("+")}|-', time)[0]
                 obj = f'{date}T{time}'
             return sc.datetime(np.datetime64(obj))
         except ValueError:

--- a/src/scippnexus/nxobject.py
+++ b/src/scippnexus/nxobject.py
@@ -365,9 +365,14 @@ class NXobject:
         values = data.values
         if data.dtype == sc.DType.string:
             values = np.array(data.values, dtype=object)
+        elif data.dtype == sc.DType.datetime64:
+            start = sc.epoch(unit=data.unit)
+            values = (data - start).values
         dataset = self._group.create_dataset(name, data=values, **kwargs)
         if data.unit is not None:
             dataset.attrs['units'] = str(data.unit)
+        if data.dtype == sc.DType.datetime64:
+            dataset.attrs['start'] = str(start.value)
         return Field(dataset, data.dims)
 
     def create_class(self, name: str, nx_class: NX_class) -> NXobject:

--- a/src/scippnexus/nxobject.py
+++ b/src/scippnexus/nxobject.py
@@ -116,7 +116,7 @@ def _as_datetime(obj: Any):
             # nanosecond precision.
             if 'T' in obj:
                 date, time = obj.split('T')
-                time = re.split(f'Z|{re.escape("+")}|-', time)[0]
+                time = re.split(r'Z|\+|-', time)[0]
                 obj = f'{date}T{time}'
             return sc.datetime(np.datetime64(obj))
         except ValueError:

--- a/src/scippnexus/nxobject.py
+++ b/src/scippnexus/nxobject.py
@@ -130,7 +130,7 @@ def _as_datetime(obj: Any):
                 dt = dt.astimezone(datetime.timezone.utc)
                 dt = dt.replace(tzinfo=None).isoformat()
                 # We operate with string operations here and thus end up parsing date
-                # and time twice. The reason is the the timezone-offset arithmetic must
+                # and time twice. The reason is that the timezone-offset arithmetic
                 # cannot be done, e.g., in nanoseconds without causing rounding errors.
                 if '.' in time:
                     dt += f".{time.split('.')[1]}"

--- a/src/scippnexus/nxobject.py
+++ b/src/scippnexus/nxobject.py
@@ -2,6 +2,7 @@
 # Copyright (c) 2022 Scipp contributors (https://github.com/scipp)
 # @author Simon Heybrock
 from __future__ import annotations
+import re
 import warnings
 from enum import Enum, auto
 import functools
@@ -111,6 +112,12 @@ def _as_datetime(obj: Any):
             # i.e., interpret time as local time. If time is given in UTC this will lead
             # to misleading results since we have no information about the actual time
             # zone.
+            # Would like to use dateutil, but with Python's datetime we do not get
+            # nanosecond precision.
+            if 'T' in obj:
+                date, time = obj.split('T')
+                time = re.split('Z|\+|-', time)[0]
+                obj = f'{date}T{time}'
             return sc.datetime(np.datetime64(obj))
         except ValueError:
             pass

--- a/src/scippnexus/nxobject.py
+++ b/src/scippnexus/nxobject.py
@@ -113,7 +113,7 @@ def _as_datetime(obj: Any):
             # i.e., convert to UTC.
             # Would like to use dateutil directly, but with Python's datetime we do not
             # get nanosecond precision. Therefore we combine numpy and dateutil parsing.
-            date_only = 'T' in obj
+            date_only = 'T' not in obj
             if date_only:
                 return sc.datetime(np.datetime64(obj))
             else:

--- a/src/scippnexus/nxobject.py
+++ b/src/scippnexus/nxobject.py
@@ -6,7 +6,6 @@ import warnings
 from enum import Enum, auto
 import functools
 from typing import List, Union, NoReturn, Any, Dict, Tuple, Protocol
-import dateutil
 import numpy as np
 import scipp as sc
 import h5py
@@ -108,14 +107,11 @@ def _is_time(obj):
 def _as_datetime(obj: Any):
     if isinstance(obj, str):
         try:
-            # datetime.fromisoformat cannot parse time zones and recommends dateutil
-            dt = dateutil.parser.isoparse(obj)
             # NumPy and scipp cannot handle timezone information. We therefore strip it,
             # i.e., interpret time as local time. If time is given in UTC this will lead
             # to misleading results since we have no information about the actual time
             # zone.
-            dt = dt.replace(tzinfo=None)
-            return sc.datetime(np.datetime64(dt), unit='ns')
+            return sc.datetime(np.datetime64(obj))
         except ValueError:
             pass
     return None

--- a/tests/nexus_test.py
+++ b/tests/nexus_test.py
@@ -222,7 +222,6 @@ def test_ms_field_with_second_datetime_attribute_loaded_as_ms_datetime(nxroot):
                      values=['2022-12-12T12:13:14.000', '2022-12-12T12:13:14.001']))
 
 
-
 def test_ns_field_with_second_datetime_attribute_loaded_as_ns_datetime(nxroot):
     nxroot['mytime'] = sc.arange('ignored', 2, unit='ns')
     nxroot['mytime'].attrs['start_time'] = '1970-01-01T00:00:00'
@@ -232,7 +231,6 @@ def test_ns_field_with_second_datetime_attribute_loaded_as_ns_datetime(nxroot):
             dims=['dim_0'],
             unit='ns',
             values=['1970-01-01T00:00:00.000000000', '1970-01-01T00:00:00.000000001']))
-
 
 
 def test_second_field_with_ns_datetime_attribute_loaded_as_ns_datetime(nxroot):
@@ -245,8 +243,8 @@ def test_second_field_with_ns_datetime_attribute_loaded_as_ns_datetime(nxroot):
                      values=['1970-01-01T00:00:00', '1970-01-01T00:00:01']))
 
 
-
-@pytest.mark.parametrize('timezone', ['Z', '+04', '+00', '-02', '+1130', '-0930', '+11:30', '-09:30'])
+@pytest.mark.parametrize(
+    'timezone', ['Z', '+04', '+00', '-02', '+1130', '-0930', '+11:30', '-09:30'])
 def test_timezone_information_in_datetime_attribute_is_dropped(nxroot, timezone):
     nxroot['mytime'] = sc.arange('ignored', 2, unit='s')
     nxroot['mytime'].attrs['start_time'] = f'1970-01-01T00:00:00{timezone}'
@@ -260,7 +258,6 @@ def test_timezone_information_in_datetime_attribute_is_dropped(nxroot, timezone)
         sc.datetimes(dims=['dim_0'],
                      unit='s',
                      values=['1970-01-01T00:00:00', '1970-01-01T00:00:01']))
-
 
 
 def create_event_data_ids_1234(group):

--- a/tests/nexus_test.py
+++ b/tests/nexus_test.py
@@ -256,9 +256,9 @@ def test_timezone_information_in_datetime_attribute_is_applied(nxroot, timezone,
 
 def test_timezone_information_in_datetime_attribute_preserves_ns_precision(nxroot):
     nxroot['mytime'] = sc.scalar(value=3, unit='s')
-    nxroot['mytime'].attrs['start_time'] = f'1970-01-01T12:00:00.123456789+0200'
+    nxroot['mytime'].attrs['start_time'] = '1970-01-01T12:00:00.123456789+0200'
     assert sc.identical(nxroot['mytime'][...],
-                        sc.datetime(unit='ns', value=f'1970-01-01T10:00:03.123456789'))
+                        sc.datetime(unit='ns', value='1970-01-01T10:00:03.123456789'))
 
 
 def test_loads_bare_timestamps_if_multiple_candidate_datetime_offsets_found(nxroot):

--- a/tests/nexus_test.py
+++ b/tests/nexus_test.py
@@ -243,16 +243,15 @@ def test_second_field_with_ns_datetime_attribute_loaded_as_ns_datetime(nxroot):
                      values=['1970-01-01T00:00:00', '1970-01-01T00:00:01']))
 
 
-@pytest.mark.parametrize(
-    'timezone', ['Z', '+04', '+00', '-02', '+1130', '-0930', '+11:30', '-09:30'])
-def test_timezone_information_in_datetime_attribute_is_dropped(nxroot, timezone):
-    nxroot['mytime'] = sc.arange('ignored', 2, unit='s')
-    nxroot['mytime'].attrs['start_time'] = f'1970-01-01T00:00:00{timezone}'
-    assert sc.identical(
-        nxroot['mytime'][...],
-        sc.datetimes(dims=['dim_0'],
-                     unit='s',
-                     values=['1970-01-01T00:00:00', '1970-01-01T00:00:01']))
+@pytest.mark.parametrize('timezone,hhmm', [('Z', '12:00'), ('+04', '08:00'),
+                                           ('+00', '12:00'), ('-02', '14:00'),
+                                           ('+1130', '00:30'), ('-0930', '21:30'),
+                                           ('+11:30', '00:30'), ('-09:30', '21:30')])
+def test_timezone_information_in_datetime_attribute_is_applied(nxroot, timezone, hhmm):
+    nxroot['mytime'] = sc.scalar(value=3, unit='s')
+    nxroot['mytime'].attrs['start_time'] = f'1970-01-01T12:00:00{timezone}'
+    assert sc.identical(nxroot['mytime'][...],
+                        sc.datetime(unit='s', value=f'1970-01-01T{hhmm}:03'))
 
 
 def test_loads_bare_timestamps_if_multiple_candidate_datetime_offsets_found(nxroot):

--- a/tests/nexus_test.py
+++ b/tests/nexus_test.py
@@ -248,11 +248,6 @@ def test_second_field_with_ns_datetime_attribute_loaded_as_ns_datetime(nxroot):
 def test_timezone_information_in_datetime_attribute_is_dropped(nxroot, timezone):
     nxroot['mytime'] = sc.arange('ignored', 2, unit='s')
     nxroot['mytime'].attrs['start_time'] = f'1970-01-01T00:00:00{timezone}'
-    print(
-        nxroot['mytime'][...],
-        sc.datetimes(dims=['dim_0'],
-                     unit='s',
-                     values=['1970-01-01T00:00:00', '1970-01-01T00:00:01']))
     assert sc.identical(
         nxroot['mytime'][...],
         sc.datetimes(dims=['dim_0'],

--- a/tests/nexus_test.py
+++ b/tests/nexus_test.py
@@ -254,6 +254,13 @@ def test_timezone_information_in_datetime_attribute_is_applied(nxroot, timezone,
                         sc.datetime(unit='s', value=f'1970-01-01T{hhmm}:03'))
 
 
+def test_timezone_information_in_datetime_attribute_preserves_ns_precision(nxroot):
+    nxroot['mytime'] = sc.scalar(value=3, unit='s')
+    nxroot['mytime'].attrs['start_time'] = f'1970-01-01T12:00:00.123456789+0200'
+    assert sc.identical(nxroot['mytime'][...],
+                        sc.datetime(unit='ns', value=f'1970-01-01T10:00:03.123456789'))
+
+
 def test_loads_bare_timestamps_if_multiple_candidate_datetime_offsets_found(nxroot):
     offsets = sc.arange('ignored', 2, unit='ms')
     nxroot['mytime'] = offsets

--- a/tests/nexus_test.py
+++ b/tests/nexus_test.py
@@ -255,6 +255,14 @@ def test_timezone_information_in_datetime_attribute_is_dropped(nxroot, timezone)
                      values=['1970-01-01T00:00:00', '1970-01-01T00:00:01']))
 
 
+def test_loads_bare_timestamps_if_multiple_candidate_datetime_offsets_found(nxroot):
+    offsets = sc.arange('ignored', 2, unit='ms')
+    nxroot['mytime'] = offsets
+    nxroot['mytime'].attrs['offset'] = '2022-12-12T12:13:14'
+    nxroot['mytime'].attrs['start_time'] = '2022-12-12T12:13:15'
+    assert sc.identical(nxroot['mytime'][...], offsets.rename(ignored='dim_0'))
+
+
 def create_event_data_ids_1234(group):
     group['event_id'] = sc.array(dims=[''], unit=None, values=[1, 2, 4, 1, 2, 2])
     group['event_time_offset'] = sc.array(dims=[''],

--- a/tests/nexus_test.py
+++ b/tests/nexus_test.py
@@ -212,6 +212,57 @@ def test_field_of_extended_ascii_in_ascii_encoded_dataset_is_loaded_correctly():
             sc.array(dims=['dim_0'], values=["run at rot=90°", "run at rot=90°x"]))
 
 
+def test_ms_field_with_second_datetime_attribute_loaded_as_ms_datetime(nxroot):
+    nxroot['mytime'] = sc.arange('ignored', 2, unit='ms')
+    nxroot['mytime'].attrs['start_time'] = '2022-12-12T12:13:14'
+    assert sc.identical(
+        nxroot['mytime'][...],
+        sc.datetimes(dims=['dim_0'],
+                     unit='ms',
+                     values=['2022-12-12T12:13:14.000', '2022-12-12T12:13:14.001']))
+
+
+
+def test_ns_field_with_second_datetime_attribute_loaded_as_ns_datetime(nxroot):
+    nxroot['mytime'] = sc.arange('ignored', 2, unit='ns')
+    nxroot['mytime'].attrs['start_time'] = '1970-01-01T00:00:00'
+    assert sc.identical(
+        nxroot['mytime'][...],
+        sc.datetimes(
+            dims=['dim_0'],
+            unit='ns',
+            values=['1970-01-01T00:00:00.000000000', '1970-01-01T00:00:00.000000001']))
+
+
+
+def test_second_field_with_ns_datetime_attribute_loaded_as_ns_datetime(nxroot):
+    nxroot['mytime'] = sc.arange('ignored', 2, unit='s')
+    nxroot['mytime'].attrs['start_time'] = '1970-01-01T00:00:00.000000000'
+    assert sc.identical(
+        nxroot['mytime'][...],
+        sc.datetimes(dims=['dim_0'],
+                     unit='ns',
+                     values=['1970-01-01T00:00:00', '1970-01-01T00:00:01']))
+
+
+
+@pytest.mark.parametrize('timezone', ['Z', '+04', '+00', '-02', '+1130', '-0930', '+11:30', '-09:30'])
+def test_timezone_information_in_datetime_attribute_is_dropped(nxroot, timezone):
+    nxroot['mytime'] = sc.arange('ignored', 2, unit='s')
+    nxroot['mytime'].attrs['start_time'] = f'1970-01-01T00:00:00{timezone}'
+    print(
+        nxroot['mytime'][...],
+        sc.datetimes(dims=['dim_0'],
+                     unit='s',
+                     values=['1970-01-01T00:00:00', '1970-01-01T00:00:01']))
+    assert sc.identical(
+        nxroot['mytime'][...],
+        sc.datetimes(dims=['dim_0'],
+                     unit='s',
+                     values=['1970-01-01T00:00:00', '1970-01-01T00:00:01']))
+
+
+
 def create_event_data_ids_1234(group):
     group['event_id'] = sc.array(dims=[''], unit=None, values=[1, 2, 4, 1, 2, 2])
     group['event_time_offset'] = sc.array(dims=[''],

--- a/tests/nexus_test.py
+++ b/tests/nexus_test.py
@@ -235,12 +235,12 @@ def test_ns_field_with_second_datetime_attribute_loaded_as_ns_datetime(nxroot):
 
 def test_second_field_with_ns_datetime_attribute_loaded_as_ns_datetime(nxroot):
     nxroot['mytime'] = sc.arange('ignored', 2, unit='s')
-    nxroot['mytime'].attrs['start_time'] = '1970-01-01T00:00:00.000000000'
+    nxroot['mytime'].attrs['start_time'] = '1984-01-01T00:00:00.000000000'
     assert sc.identical(
         nxroot['mytime'][...],
         sc.datetimes(dims=['dim_0'],
                      unit='ns',
-                     values=['1970-01-01T00:00:00', '1970-01-01T00:00:01']))
+                     values=['1984-01-01T00:00:00', '1984-01-01T00:00:01']))
 
 
 @pytest.mark.parametrize('timezone,hhmm', [('Z', '12:00'), ('+04', '08:00'),
@@ -249,16 +249,16 @@ def test_second_field_with_ns_datetime_attribute_loaded_as_ns_datetime(nxroot):
                                            ('+11:30', '00:30'), ('-09:30', '21:30')])
 def test_timezone_information_in_datetime_attribute_is_applied(nxroot, timezone, hhmm):
     nxroot['mytime'] = sc.scalar(value=3, unit='s')
-    nxroot['mytime'].attrs['start_time'] = f'1970-01-01T12:00:00{timezone}'
+    nxroot['mytime'].attrs['start_time'] = f'1984-01-01T12:00:00{timezone}'
     assert sc.identical(nxroot['mytime'][...],
-                        sc.datetime(unit='s', value=f'1970-01-01T{hhmm}:03'))
+                        sc.datetime(unit='s', value=f'1984-01-01T{hhmm}:03'))
 
 
 def test_timezone_information_in_datetime_attribute_preserves_ns_precision(nxroot):
     nxroot['mytime'] = sc.scalar(value=3, unit='s')
-    nxroot['mytime'].attrs['start_time'] = '1970-01-01T12:00:00.123456789+0200'
+    nxroot['mytime'].attrs['start_time'] = '1984-01-01T12:00:00.123456789+0200'
     assert sc.identical(nxroot['mytime'][...],
-                        sc.datetime(unit='ns', value='1970-01-01T10:00:03.123456789'))
+                        sc.datetime(unit='ns', value='1984-01-01T10:00:03.123456789'))
 
 
 def test_loads_bare_timestamps_if_multiple_candidate_datetime_offsets_found(nxroot):

--- a/tests/nxdata_test.py
+++ b/tests/nxdata_test.py
@@ -302,6 +302,7 @@ def test_unnamed_extra_dims_of_multidim_coords_are_squeezed(nxroot):
     assert data['xx'].shape == [2]
     assert sc.identical(data['xx'][...], xx['ignored', 0])
 
+
 def test_fields_with_datetime_attribute_are_loaded_as_datetime(nxroot):
     da = sc.DataArray(
         sc.epoch(unit='s') +

--- a/tests/nxdata_test.py
+++ b/tests/nxdata_test.py
@@ -1,4 +1,5 @@
 import h5py
+import numpy as np
 import scipp as sc
 from scippnexus import NXroot, NX_class
 import pytest
@@ -211,6 +212,15 @@ def test_create_field_from_variable(nxroot, unit):
     loaded = nxroot['field'][...]
     # Nexus does not support storing dim labels
     assert sc.identical(loaded, var.rename(xx=loaded.dim))
+
+
+def test_create_datetime_field_from_variable(nxroot):
+    var = sc.datetime(np.datetime64('now'), unit='ns') + sc.arange(
+        'time', 1, 4, dtype='int64', unit='ns')
+    nxroot.create_field('field', var)
+    loaded = nxroot['field'][...]
+    # Nexus does not support storing dim labels
+    assert sc.identical(loaded, var.rename(time=loaded.dim))
 
 
 @pytest.mark.parametrize("nx_class", [NX_class.NXdata, NX_class.NXlog])

--- a/tests/nxdata_test.py
+++ b/tests/nxdata_test.py
@@ -301,3 +301,20 @@ def test_unnamed_extra_dims_of_multidim_coords_are_squeezed(nxroot):
     assert data['xx'].ndim == 1
     assert data['xx'].shape == [2]
     assert sc.identical(data['xx'][...], xx['ignored', 0])
+
+def test_fields_with_datetime_attribute_are_loaded_as_datetime(nxroot):
+    da = sc.DataArray(
+        sc.epoch(unit='s') +
+        sc.array(dims=['xx', 'yy'], unit='s', values=[[1, 2, 3], [4, 5, 6]]))
+    da.coords['xx'] = da.data['yy', 0]
+    da.coords['xx2'] = da.data['yy', 1]
+    da.coords['yy'] = da.data['xx', 0]
+    data = nxroot.create_class('data1', NX_class.NXdata)
+    data.attrs['axes'] = da.dims
+    data.attrs['signal'] = 'signal'
+    data.create_field('signal', da.data)
+    data.create_field('xx', da.coords['xx'])
+    data.create_field('xx2', da.coords['xx2'])
+    data.create_field('yy', da.coords['yy'])
+    print(data[...], da)
+    assert sc.identical(data[...], da)

--- a/tests/nxdata_test.py
+++ b/tests/nxdata_test.py
@@ -316,5 +316,4 @@ def test_fields_with_datetime_attribute_are_loaded_as_datetime(nxroot):
     data.create_field('xx', da.coords['xx'])
     data.create_field('xx2', da.coords['xx2'])
     data.create_field('yy', da.coords['yy'])
-    print(data[...], da)
     assert sc.identical(data[...], da)


### PR DESCRIPTION
Previously only a datetime offset attribute for `NXlog['time']` and `event_time_zero` in `NXevent_data` was loaded. This PR removes this special-case handling and instead attempts to do so for *all* fields. Rationale is as follows:

- HDF5 does not support storing datetime64.
- According to private communication with Tobias Richter (on the Nexus committee), interpreting start/offset attributes *is* standard (or in the spirit if the standard), even though this is not documented anywhere.

Related changes:

- Try to preserve precision of date in file instead of converting everything to nanoseconds.
- Work around numpy timezone deprecation warnings.