### PR TITLE
Add nbstripout pre-commit hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,11 +1,16 @@
 repos:
-  -   repo: https://github.com/pycqa/flake8
-      rev: 3.8.3
-      hooks:
-        - id: flake8
-  -   repo: https://github.com/pre-commit/mirrors-yapf
-      rev: v0.30.0
-      hooks:
-        - id: yapf
-          args: ["-i", "-r"]
-          files: "python"
+- repo: https://github.com/pycqa/flake8
+  rev: 3.8.3
+  hooks:
+    - id: flake8
+- repo: https://github.com/pre-commit/mirrors-yapf
+  rev: v0.30.0
+  hooks:
+    - id: yapf
+      args: ["-i", "-r"]
+      files: "python"
+- repo: https://github.com/kynan/nbstripout
+  rev: 0.5.0
+  hooks:
+    - id: nbstripout
+      args: ['--extra-keys', 'metadata.language_info.version cell.metadata.jp-MarkdownHeadingCollapsed', '--strip-empty-cells']

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -7,8 +7,6 @@ repos:
   rev: v0.30.0
   hooks:
     - id: yapf
-      args: ["-i", "-r"]
-      files: "python"
 - repo: https://github.com/kynan/nbstripout
   rev: 0.5.0
   hooks:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,11 @@
+repos:
+  -   repo: https://github.com/pycqa/flake8
+      rev: 3.8.3
+      hooks:
+        - id: flake8
+  -   repo: https://github.com/pre-commit/mirrors-yapf
+      rev: v0.30.0
+      hooks:
+        - id: yapf
+          args: ["-i", "-r"]
+          files: "python"


### PR DESCRIPTION
- Copy config from scipp repo
- Add `nbstripout`. This is slightly different from `nb-clean` used in CI, but has the advantage of being usable as a pre-commit hook. If it works, my plan is to also use this in CI.