### PR TITLE
Manual requirement updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,9 +8,3 @@ updates:
       # Optional: Official actions have moving tags like v1;
       # if you use those, you don't need updates.
       - dependency-name: "actions/*"
-  - package-ecosystem: "pip"
-    directory: "/requirements"
-    schedule:
-      interval: "daily"
-    open-pull-requests-limit: 10
-    versioning-strategy: lockfile-only

--- a/requirements/docs.txt
+++ b/requirements/docs.txt
@@ -20,12 +20,12 @@ babel==2.9.1
     # via sphinx
 backcall==0.2.0
     # via ipython
-beautifulsoup4==4.10.0
+beautifulsoup4==4.11.1
     # via
     #   nbconvert
     #   pydata-sphinx-theme
     #   sphinx-book-theme
-bleach==4.1.0
+bleach==5.0.0
     # via nbconvert
 certifi==2021.10.8
     # via requests
@@ -55,7 +55,7 @@ executing==0.8.3
     # via stack-data
 fastjsonschema==2.15.3
     # via nbformat
-fonttools==4.31.2
+fonttools==4.32.0
     # via matplotlib
 idna==3.3
     # via requests
@@ -101,7 +101,7 @@ jupyter-core==4.9.2
     #   nbconvert
     #   nbformat
     #   notebook
-jupyterlab-pygments==0.1.2
+jupyterlab-pygments==0.2.0
     # via nbconvert
 jupyterlab-widgets==1.1.0
     # via ipywidgets
@@ -146,7 +146,6 @@ numpy==1.22.3
     # via matplotlib
 packaging==21.3
     # via
-    #   bleach
     #   ipykernel
     #   matplotlib
     #   pooch
@@ -163,7 +162,7 @@ pillow==9.1.0
     # via matplotlib
 pooch==1.6.0
     # via -r docs.in
-prometheus-client==0.14.0
+prometheus-client==0.14.1
     # via notebook
 prompt-toolkit==3.0.29
     # via ipython
@@ -182,10 +181,9 @@ pydata-sphinx-theme==0.7.2
 pygments==2.11.2
     # via
     #   ipython
-    #   jupyterlab-pygments
     #   nbconvert
     #   sphinx
-pyparsing==3.0.7
+pyparsing==3.0.8
     # via
     #   matplotlib
     #   packaging


### PR DESCRIPTION
- Disable dependabot for pip requirements. As discussed this would likely cause to many updates (of individual packages) that we do not care about.
- Ran `cd requirements && pip-compile -U docs` to get a feel how manual updating works.
  - Will consider setting up a cron-job for this, after we have some more experience.