### PR TITLE
Fix NXdetector for 0-D detector_number field.

### DIFF
--- a/src/scippnexus/nxdetector.py
+++ b/src/scippnexus/nxdetector.py
@@ -80,7 +80,8 @@ class _EventField:
                                         dtype=id_min.dtype)
         else:
             detector_number = self._detector_number[select]
-        event_id = detector_number.flatten(to='event_id')
+        # copy since sc.bin cannot deal with a non-contiguous view
+        event_id = detector_number.flatten(to='event_id').copy()
         event_data.bins.coords['event_time_zero'] = sc.bins_like(
             event_data, fill_value=event_data.coords['event_time_zero'])
         # After loading raw NXevent_data it is guaranteed that the event table

--- a/tests/nxdetector_test.py
+++ b/tests/nxdetector_test.py
@@ -106,8 +106,7 @@ def test_loads_event_data_with_0d_detector_numbers(nxroot):
     assert detector.dims == []
     assert detector.shape == []
     loaded = detector[...]
-    assert sc.identical(loaded.bins.size().data,
-                        sc.array(dims=[], unit=None, dtype='int64', values=2))
+    assert sc.identical(loaded.bins.size().data, sc.index(2, dtype='int64'))
 
 
 def test_loads_event_data_with_2d_detector_numbers(nxroot):

--- a/tests/nxdetector_test.py
+++ b/tests/nxdetector_test.py
@@ -99,6 +99,17 @@ def test_loads_event_data_mapped_to_detector_numbers_based_on_their_event_id(nxr
     assert 'event_time_zero' in loaded.bins.coords
 
 
+def test_loads_event_data_with_0d_detector_numbers(nxroot):
+    detector = nxroot.create_class('detector0', NX_class.NXdetector)
+    detector.create_field('detector_number', sc.index(1, dtype='int64'))
+    create_event_data_ids_1234(detector.create_class('events', NX_class.NXevent_data))
+    assert detector.dims == []
+    assert detector.shape == []
+    loaded = detector[...]
+    assert sc.identical(loaded.bins.size().data,
+                        sc.array(dims=[], unit=None, dtype='int64', values=2))
+
+
 def test_loads_event_data_with_2d_detector_numbers(nxroot):
     detector = nxroot.create_class('detector0', NX_class.NXdetector)
     detector.create_field('detector_number', detector_numbers_xx_yy_1234())


### PR DESCRIPTION
This also matters when shape=(1,) since this is considered equivalent to shape=() in Nexus