### PR TITLE
Avoid squeezing in NXlog of length 1

### DIFF
--- a/src/scippnexus/nxlog.py
+++ b/src/scippnexus/nxlog.py
@@ -28,7 +28,10 @@ class NXlog(NXobject):
         # The outermost axis in NXlog is pre-defined to 'time' (if present). Note
         # that this may be overriden by an `axes` attribute, if defined for the group.
         if 'time' in self:
-            axes[0] = 'time'
+            if len(axes) == 0:  # shape=(1,) was squeezed, log has only a single value
+                axes = ['time']
+            else:
+                axes[0] = 'time'
         # NXdata uses the 'signal' attribute to define the field name of the signal.
         # NXlog uses a "hard-coded" signal name 'value', without specifying the
         # attribute in the file, so we pass this explicitly to NXdata.

--- a/tests/nexus_test.py
+++ b/tests/nexus_test.py
@@ -82,6 +82,21 @@ def test_nxobject_log(nxroot):
     assert sc.identical(log[...], da)
 
 
+def test_nxobject_log_length_1(nxroot):
+    da = sc.DataArray(
+        sc.array(dims=['time'], values=[1.1]),
+        coords={
+            'time':
+            sc.epoch(unit='ns') +
+            sc.array(dims=['time'], unit='s', values=[4.4]).to(unit='ns', dtype='int64')
+        })
+    log = nxroot['entry'].create_class('log', NX_class.NXlog)
+    log['value'] = da.data
+    log['time'] = da.coords['time'] - sc.epoch(unit='ns')
+    assert log.nx_class == NX_class.NXlog
+    assert sc.identical(log[...], da)
+
+
 def test_nxobject_event_data(nxroot):
     event_data = nxroot['entry'].create_class('events_0', NX_class.NXevent_data)
     assert event_data.nx_class == NX_class.NXevent_data


### PR DESCRIPTION
This previously led to an exception.