### PR TITLE
Fix broken setup of dims for fields that have an AXISNAME_indices attr

### DIFF
--- a/docs/_templates/topbar/launchbuttons.html
+++ b/docs/_templates/topbar/launchbuttons.html
@@ -12,8 +12,8 @@
             href="https://scipp.github.io/scippnexus"><button type="button"
                 class="btn btn-secondary topbarbtn">latest</button></a>
         <a class="dropdown-buttons"
-            href="https://scipp.github.io/scippnexus/release/0.0.4"><button type="button"
-                class="btn btn-secondary topbarbtn">v0.0.4</button></a>
+            href="https://scipp.github.io/scippnexus/release/0.0.7"><button type="button"
+                class="btn btn-secondary topbarbtn">v0.0.7</button></a>
     </div>
 </div>
 <div class="dropdown-buttons-trigger">

--- a/src/scippnexus/nxdata.py
+++ b/src/scippnexus/nxdata.py
@@ -120,7 +120,7 @@ class NXdata(NXobject):
         # standard recommends that readers should also make "best effort" guess
         # since legacy files do not set this attribute.
         if (indices := self.attrs.get(f'{name}_indices')) is not None:
-            return np.array(self.dims)[np.array(indices).flatten()]
+            return list(np.array(self.dims)[np.array(indices).flatten()])
         signals = [self._signal_name, self._errors_name]
         signals += list(self.attrs.get('auxiliary_signals', []))
         if name in signals:

--- a/tests/nxdata_test.py
+++ b/tests/nxdata_test.py
@@ -144,6 +144,19 @@ def test_indices_attribute_for_coord(nxroot, indices):
     assert sc.identical(data[...], da)
 
 
+@pytest.mark.parametrize("indices", [1, [1]], ids=['int', 'list-of-int'])
+def test_indices_attribute_for_coord_with_nontrivial_slice(nxroot, indices):
+    da = sc.DataArray(sc.array(dims=['xx', 'yy'], unit='m', values=[[1, 2], [4, 5]]))
+    da.coords['yy2'] = da.data['xx', 0]
+    data = nxroot.create_class('data1', NX_class.NXdata)
+    data.attrs['axes'] = da.dims
+    data.attrs['signal'] = 'signal'
+    data.attrs['yy2_indices'] = indices
+    data.create_field('signal', da.data)
+    data.create_field('yy2', da.coords['yy2'])
+    assert sc.identical(data['yy', :1], da['yy', :1])
+
+
 def test_transpose_indices_attribute_for_coord(nxroot):
     da = sc.DataArray(sc.array(dims=['xx', 'yy'], unit='m', values=[[1, 2], [4, 5]]))
     da.coords['xx2'] = sc.transpose(da.data)


### PR DESCRIPTION
The passed an numpy ndarray, leading to an exception later on.