### PR TITLE
Generalize nxmonitor

### DIFF
--- a/src/scippnexus/nxdetector.py
+++ b/src/scippnexus/nxdetector.py
@@ -32,10 +32,12 @@ class _EventField:
     def __init__(self,
                  nxevent_data: NXevent_data,
                  event_select: ScippIndex,
-                 detector_number: Optional[Field] = None):
+                 groups_key: Optional[str] = 'detector_number',
+                 groups: Optional[Field] = None):
         self._nxevent_data = nxevent_data
         self._event_select = event_select
-        self._detector_number = detector_number
+        self._groups_key = groups_key
+        self._groups = groups
 
     @property
     def attrs(self):
@@ -43,17 +45,17 @@ class _EventField:
 
     @property
     def dims(self):
-        if self._detector_number is None:
+        if self._groups is None:
             return ['detector_number']
-        return self._detector_number.dims
+        return self._groups.dims
 
     @property
     def shape(self):
-        if self._detector_number is None:
+        if self._groups is None:
             raise NexusStructureError(
                 "Cannot get shape of NXdetector since no 'detector_number' "
                 "field found but detector contains event data.")
-        return self._detector_number.shape
+        return self._groups.shape
 
     @property
     def unit(self):
@@ -61,7 +63,7 @@ class _EventField:
 
     def __getitem__(self, select: ScippIndex) -> sc.DataArray:
         event_data: sc.DataArray = self._nxevent_data[self._event_select]
-        if self._detector_number is None:
+        if self._groups is None:
             if select not in (Ellipsis, tuple(), slice(None)):
                 raise NexusStructureError(
                     "Cannot load slice of NXdetector since it contains event data "
@@ -73,15 +75,18 @@ class _EventField:
             # (NXevent_data).
             id_min = event_data.bins.coords['event_id'].min()
             id_max = event_data.bins.coords['event_id'].max()
-            detector_number = sc.arange(dim='detector_number',
-                                        unit=None,
-                                        start=id_min.value,
-                                        stop=id_max.value + 1,
-                                        dtype=id_min.dtype)
+            groups = sc.arange(dim=self._groups_key,
+                               unit=None,
+                               start=id_min.value,
+                               stop=id_max.value + 1,
+                               dtype=id_min.dtype)
         else:
-            detector_number = self._detector_number[select]
+            groups = self._groups[select]
+            if (self._groups_key in event_data.coords) and sc.identical(
+                    groups, event_data.coords[self._groups_key]):
+                return event_data
         # copy since sc.bin cannot deal with a non-contiguous view
-        event_id = detector_number.flatten(to='event_id').copy()
+        event_id = groups.flatten(to='event_id').copy()
         event_data.bins.coords['event_time_zero'] = sc.bins_like(
             event_data, fill_value=event_data.coords['event_time_zero'])
         # After loading raw NXevent_data it is guaranteed that the event table
@@ -89,11 +94,11 @@ class _EventField:
         # more efficient approach of binning from scratch instead of erasing the
         # 'pulse' binning defined by NXevent_data.
         event_data = sc.bin(event_data.bins.constituents['data'], groups=[event_id])
-        if self._detector_number is None:
-            event_data.coords['detector_number'] = event_data.coords.pop('event_id')
+        if self._groups is None:
+            event_data.coords[self._groups_key] = event_data.coords.pop('event_id')
         else:
             del event_data.coords['event_id']
-        return event_data.fold(dim='event_id', sizes=detector_number.sizes)
+        return event_data.fold(dim='event_id', sizes=groups.sizes)
 
 
 class NXdetector(NXobject):
@@ -124,11 +129,11 @@ class NXdetector(NXobject):
         return self._signal.unit
 
     @property
-    def _detector_number(self) -> Union[None, Field]:
+    def _event_grouping(self) -> Union[None, Field]:
         for key in self._detector_number_fields:
             if key in self:
-                return self[key]
-        return None
+                return {'groups_key': key, 'groups': self[key]}
+        return {}
 
     @property
     def _signal(self) -> Union[Field, _EventField]:
@@ -136,7 +141,8 @@ class NXdetector(NXobject):
 
     def _nxdata(self, use_event_signal=True) -> NXdata:
         if use_event_signal and self.events is not None:
-            signal = _EventField(self.events, self._event_select, self._detector_number)
+            signal = _EventField(self.events, self._event_select,
+                                 **self._event_grouping)
         else:
             signal = None
         # NXdata uses the 'signal' attribute to define the field name of the signal.

--- a/src/scippnexus/nxmonitor.py
+++ b/src/scippnexus/nxmonitor.py
@@ -1,59 +1,15 @@
 # SPDX-License-Identifier: BSD-3-Clause
 # Copyright (c) 2022 Scipp contributors (https://github.com/scipp)
 # @author Simon Heybrock
-from typing import List, Union
-import warnings
-import scipp as sc
-from .nxevent_data import NXevent_data
-from .nxobject import NXobject, ScippIndex
-from .nxdata import NXdata
+from typing import Dict, Union
+from .nxobject import Field
+from .nxdetector import NXdetector
 
 
-class NXmonitor(NXobject):
+class NXmonitor(NXdetector):
     @property
-    def shape(self) -> List[int]:
-        return self._nxbase.shape
-
-    @property
-    def dims(self) -> List[str]:
-        return self._nxbase.dims
-
-    @property
-    def unit(self) -> Union[sc.Unit, None]:
-        return self._nxbase.unit
-
-    @property
-    def _is_events(self) -> bool:
-        return 'event_time_offset' in self
-
-    @property
-    def _nxbase(self) -> Union[NXdata, NXevent_data]:
-        """Branch between event-mode and histogram-mode monitor."""
-        if self._is_events:
-            return NXevent_data(self._group)
-        # NXdata uses the 'signal' attribute to define the field name of the signal.
-        # NXmonitor uses a "hard-coded" signal name 'data', without specifying the
-        # attribute in the file, so we pass this explicitly to NXdata.
-        return NXdata(self._group, signal_name_default='data')
-
-    def _get_field_dims(self, name: str) -> Union[None, List[str]]:
-        if self._is_events:
-            if name in [
-                    'event_time_zero', 'event_index', 'event_time_offset', 'event_id'
-            ]:
-                # Event field is direct child of this class
-                return self._nxbase._get_field_dims(name)
-            else:
-                return self.dims
-        return self._nxbase._get_field_dims(name)
-
-    def _getitem(self, select: ScippIndex) -> sc.DataArray:
-        """
-        Load monitor data. Event-mode data takes precedence over histogram-mode data.
-        """
-        nxbase = self._nxbase
-        if isinstance(nxbase, NXevent_data) and 'data' in self:
-            warnings.warn(f"Event data present in NXmonitor group {self.name}. "
-                          f"Histogram-mode monitor data from this group will be "
-                          f"ignored.")
-        return nxbase[select]
+    def _event_grouping(self) -> Dict[str, Union[str, Field]]:
+        return {
+            'groups_key': 'event_time_zero',
+            'groups': self.events['event_time_zero']
+        }

--- a/src/scippnexus/nxmonitor.py
+++ b/src/scippnexus/nxmonitor.py
@@ -9,6 +9,10 @@ from .nxdetector import NXdetector
 class NXmonitor(NXdetector):
     @property
     def _event_grouping(self) -> Dict[str, Union[str, Field]]:
+        # Unlike NXdetector, NXmonitor does not group by 'detector_number'. We pass
+        # grouping information does matches the underlying binning of NXevent_data
+        # such that no addition binning will need to be performed. That is, the by-pulse
+        # binning present in the file (in NXevent_data) is preserved.
         return {
             'groups_key': 'event_time_zero',
             'groups': self.events['event_time_zero']

--- a/tests/nexus_test.py
+++ b/tests/nexus_test.py
@@ -55,18 +55,6 @@ def test_nxobject_entry(nxroot):
     assert set(entry.keys()) == {'events_0', 'events_1', 'log'}
 
 
-def test_nxobject_monitor(nxroot):
-    monitor = nxroot['entry'].create_class('monitor', NX_class.NXmonitor)
-    assert monitor.nx_class == NX_class.NXmonitor
-    da = sc.DataArray(
-        sc.array(dims=['time_of_flight'], values=[1.0]),
-        coords={'time_of_flight': sc.array(dims=['time_of_flight'], values=[1.0])})
-    monitor['data'] = da.data
-    monitor['data'].attrs['axes'] = 'time_of_flight'
-    monitor['time_of_flight'] = da.coords['time_of_flight']
-    assert sc.identical(monitor[...], da)
-
-
 def test_nxobject_log(nxroot):
     da = sc.DataArray(sc.array(dims=['time'], values=[1.1, 2.2, 3.3]),
                       coords={

--- a/tests/nxmonitor_test.py
+++ b/tests/nxmonitor_test.py
@@ -1,0 +1,56 @@
+import h5py
+import scipp as sc
+from scippnexus import NXroot, NX_class
+import pytest
+
+
+@pytest.fixture()
+def nxroot(request):
+    """Yield NXroot containing a single NXentry named 'entry'"""
+    with h5py.File('dummy.nxs', mode='w', driver="core", backing_store=False) as f:
+        root = NXroot(f)
+        root.create_class('entry', NX_class.NXentry)
+        yield root
+
+
+def test_dense_monitor(nxroot):
+    monitor = nxroot['entry'].create_class('monitor', NX_class.NXmonitor)
+    assert monitor.nx_class == NX_class.NXmonitor
+    da = sc.DataArray(
+        sc.array(dims=['time_of_flight'], values=[1.0]),
+        coords={'time_of_flight': sc.array(dims=['time_of_flight'], values=[1.0])})
+    monitor['data'] = da.data
+    monitor['data'].attrs['axes'] = 'time_of_flight'
+    monitor['time_of_flight'] = da.coords['time_of_flight']
+    assert sc.identical(monitor[...], da)
+
+
+def create_event_data_no_ids(group):
+    group.create_field('event_time_offset',
+                       sc.array(dims=[''], unit='s', values=[456, 7, 3, 345, 632, 23]))
+    group.create_field('event_time_zero',
+                       sc.array(dims=[''], unit='s', values=[1, 2, 3, 4]))
+    group.create_field('event_index',
+                       sc.array(dims=[''], unit='None', values=[0, 3, 3, 5]))
+
+
+def test_loads_event_data_in_current_group(nxroot):
+    monitor = nxroot.create_class('monitor1', NX_class.NXmonitor)
+    create_event_data_no_ids(monitor)
+    assert monitor.dims == ['pulse']
+    assert monitor.shape == [4]
+    loaded = monitor[...]
+    assert sc.identical(
+        loaded.bins.size().data,
+        sc.array(dims=['pulse'], unit=None, dtype='int64', values=[3, 0, 2, 1]))
+
+
+def test_loads_event_data_in_child_group(nxroot):
+    monitor = nxroot.create_class('monitor1', NX_class.NXmonitor)
+    create_event_data_no_ids(monitor.create_class('events', NX_class.NXevent_data))
+    assert monitor.dims == ['pulse']
+    assert monitor.shape == [4]
+    loaded = monitor[...]
+    assert sc.identical(
+        loaded.bins.size().data,
+        sc.array(dims=['pulse'], unit=None, dtype='int64', values=[3, 0, 2, 1]))


### PR DESCRIPTION
This should fix scipp/scippneutron#287 and scipp/scippneutron#297 (which are actually the same, I think?).

By using NXdetector we furthermore reduce code duplication, and NXmonitor now supports what NXdetector does, i.e., selecting events., etc.