### PR TITLE
Dynamic properties based on classes found in group

### DIFF
--- a/src/scippnexus/nxobject.py
+++ b/src/scippnexus/nxobject.py
@@ -29,6 +29,7 @@ class DimensionedArray(Protocol):
 
     Could be, e.g., a scipp.Variable or a dimple dataclass wrapping a numpy array.
     """
+
     @property
     def values(self):
         """Multi-dimensional array of values"""
@@ -43,6 +44,7 @@ class DimensionedArray(Protocol):
 
 
 class AttributeManager(Protocol):
+
     def __getitem__(self, name: str):
         """Get attribute"""
 
@@ -71,6 +73,7 @@ class NX_class(Enum):
 class Attrs:
     """HDF5 attributes.
     """
+
     def __init__(self, attrs: AttributeManager):
         self._attrs = attrs
 
@@ -145,6 +148,7 @@ class Field:
 
     In HDF5 fields are represented as dataset.
     """
+
     def __init__(self, dataset: H5Dataset, dims=None, is_time=None):
         self._dataset = dataset
         self._shape = list(self._dataset.shape)
@@ -485,6 +489,7 @@ class NXobject:
 
 class NXroot(NXobject):
     """Root of a NeXus file."""
+
     @property
     def nx_class(self) -> NX_class:
         # As an oversight in the NeXus standard and the reference implementation,


### PR DESCRIPTION
This is the most basic (and uncontroversial) part of what we discussed as part of scipp/scippneutron#359. This dynamically "adds" properties (by defining `__getattr__`), based on which NX_class instances are found in the current group (scippnexus.NXobject).

The code is *not* meant for review yet (a couple things to fix), for now please just try this out and comment on:

- Is this functionality what we want?
- Does the tab-completion work and make sense to you?
- etc.

To test:

```python
import scippnexus as snx
from scippnexus import data
path = data.get_path('PG3_4844_event.nxs')
f = snx.File(path)
```
then try things such as:

```
f.entry
f.entry.sample
f.entry.instrument.detector
f.entry.instrument.detectors
```