### PR TITLE
Switch to using classes as keys and add child selection based on NX_class

### DIFF
--- a/docs/_templates/scipp-class-template.rst
+++ b/docs/_templates/scipp-class-template.rst
@@ -4,6 +4,7 @@
 
 .. autoclass:: {{ objname }}
    :members:
+   :special-members: __getitem__
 
    {% block methods %}
    .. automethod:: __init__

--- a/docs/about/release-notes.rst
+++ b/docs/about/release-notes.rst
@@ -3,6 +3,30 @@
 Release Notes
 =============
 
+v0.2.0 (September 2022)
+-----------------------
+
+Features
+~~~~~~~~
+
+* :meth:`scippnexus.NXobject.__getitem__` now accepts classes such as :class:`scippnexus.NXlog` or :class:`scippnexus.NXdata` as key and returns all direct children with an ``NX_class`` attribute matching the provided class `#48 <https://github.com/scipp/scipp/pull/48>`_.
+
+Breaking changes
+~~~~~~~~~~~~~~~~
+
+* The ``NX_class`` enum has been removed. Use classes such as ``NXlog`` as keys from now on `#48 <https://github.com/scipp/scipp/pull/48>`_.
+* The ``by_nx_class`` method has been removed `#48 <https://github.com/scipp/scipp/pull/48>`_.
+
+Bugfixes
+~~~~~~~~
+
+Contributors
+~~~~~~~~~~~~
+
+Simon Heybrock :sup:`a`
+Neil Vaytet :sup:`a`\ ,
+and Jan-Lukas Wynen :sup:`a`
+
 v0.1.3 (June 2022)
 ------------------
 
@@ -31,3 +55,7 @@ Contributors
 Simon Heybrock :sup:`a`\ ,
 Neil Vaytet :sup:`a`\ ,
 and Jan-Lukas Wynen :sup:`a`
+
+Contributing Organizations
+--------------------------
+* :sup:`a`\  `European Spallation Source ERIC <https://europeanspallationsource.se/>`_, Sweden

--- a/src/scippnexus/__init__.py
+++ b/src/scippnexus/__init__.py
@@ -17,7 +17,7 @@ from .nxdisk_chopper import NXdisk_chopper
 from .nxevent_data import NXevent_data
 from .nxlog import NXlog
 from .nxmonitor import NXmonitor
-from .nxobject import NX_class, NXobject, Field
+from .nxobject import NXobject, Field
 from .nxobject import NXentry, NXinstrument, NXroot, NXtransformations
 from .nxobject import NexusStructureError
 from .nxsample import NXsample

--- a/src/scippnexus/nxdetector.py
+++ b/src/scippnexus/nxdetector.py
@@ -20,6 +20,7 @@ def group(da: sc.DataArray, groups: sc.Variable) -> sc.DataArray:
 class EventSelector:
     """A proxy object for creating an NXdetector based on a selection of events.
     """
+
     def __init__(self, detector):
         self._detector = detector
 
@@ -36,6 +37,7 @@ class _EventField:
     This has no equivalent in the NeXus format, but represents the conceptual
     event-data "signal" dataset of an NXdetector.
     """
+
     def __init__(self,
                  nxevent_data: NXevent_data,
                  event_select: ScippIndex,
@@ -115,6 +117,7 @@ class NXdetector(NXobject):
     is used to map event do detector pixels. Otherwise this returns event data in the
     same format as NXevent_data.
     """
+
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self._event_select = tuple()

--- a/src/scippnexus/nxdetector.py
+++ b/src/scippnexus/nxdetector.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from copy import copy
 from typing import List, Optional, Union
 import scipp as sc
-from .nxobject import NX_class, NXobject, Field, ScippIndex, NexusStructureError
+from .nxobject import NXobject, Field, ScippIndex, NexusStructureError
 from .nxdata import NXdata
 from .nxevent_data import NXevent_data
 
@@ -20,7 +20,6 @@ def group(da: sc.DataArray, groups: sc.Variable) -> sc.DataArray:
 class EventSelector:
     """A proxy object for creating an NXdetector based on a selection of events.
     """
-
     def __init__(self, detector):
         self._detector = detector
 
@@ -37,7 +36,6 @@ class _EventField:
     This has no equivalent in the NeXus format, but represents the conceptual
     event-data "signal" dataset of an NXdetector.
     """
-
     def __init__(self,
                  nxevent_data: NXevent_data,
                  event_select: ScippIndex,
@@ -117,7 +115,6 @@ class NXdetector(NXobject):
     is used to map event do detector pixels. Otherwise this returns event data in the
     same format as NXevent_data.
     """
-
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self._event_select = tuple()
@@ -170,7 +167,7 @@ class NXdetector(NXobject):
         # The standard is unclear on whether the 'data' field may be NXevent_data or
         # whether the fields of NXevent_data should be stored directly within this
         # NXdetector. Both cases are observed in the wild.
-        event_entries = self.by_nx_class()[NX_class.NXevent_data]
+        event_entries = self[NXevent_data]
         if len(event_entries) > 1:
             raise NexusStructureError("No unique NXevent_data entry in NXdetector. "
                                       f"Found {len(event_entries)}.")

--- a/src/scippnexus/nxobject.py
+++ b/src/scippnexus/nxobject.py
@@ -3,6 +3,7 @@
 # @author Simon Heybrock
 from __future__ import annotations
 import re
+import inspect
 import warnings
 import datetime
 import dateutil.parser
@@ -29,7 +30,6 @@ class DimensionedArray(Protocol):
 
     Could be, e.g., a scipp.Variable or a dimple dataclass wrapping a numpy array.
     """
-
     @property
     def values(self):
         """Multi-dimensional array of values"""
@@ -44,7 +44,6 @@ class DimensionedArray(Protocol):
 
 
 class AttributeManager(Protocol):
-
     def __getitem__(self, name: str):
         """Get attribute"""
 
@@ -73,7 +72,6 @@ class NX_class(Enum):
 class Attrs:
     """HDF5 attributes.
     """
-
     def __init__(self, attrs: AttributeManager):
         self._attrs = attrs
 
@@ -148,7 +146,6 @@ class Field:
 
     In HDF5 fields are represented as dataset.
     """
-
     def __init__(self, dataset: H5Dataset, dims=None, is_time=None):
         self._dataset = dataset
         self._shape = list(self._dataset.shape)
@@ -296,7 +293,6 @@ class Field:
 class NXobject:
     """Base class for all NeXus groups.
     """
-
     def __init__(self, group: H5Group):
         self._group = group
         self.child_params = {}
@@ -320,9 +316,18 @@ class NXobject:
             da.coords['depends_on'] = t if isinstance(t, sc.Variable) else sc.scalar(t)
         return da
 
+    def _get_children_by_nx_class(self, select: type) -> Dict['NXobject']:
+        return {
+            key: value
+            for key, value in self.items()
+            if (nx_class := value.attrs.get('NX_class')) == select.__name__
+        }
+
     def __getitem__(
             self,
             name: NXobjectIndex) -> Union['NXobject', Field, sc.DataArray, sc.Dataset]:
+        if inspect.isclass(name) and issubclass(name, NXobject):
+            return self._get_children_by_nx_class(name)
         return self._get_child(name, use_field_dims=True)
 
     def _getitem(self, index: ScippIndex) -> Union[sc.DataArray, sc.Dataset]:
@@ -441,7 +446,6 @@ class NXobject:
 
 class NXroot(NXobject):
     """Root of a NeXus file."""
-
     @property
     def nx_class(self) -> NX_class:
         # As an oversight in the NeXus standard and the reference implementation,

--- a/src/scippnexus/nxobject.py
+++ b/src/scippnexus/nxobject.py
@@ -29,6 +29,7 @@ class DimensionedArray(Protocol):
 
     Could be, e.g., a scipp.Variable or a dimple dataclass wrapping a numpy array.
     """
+
     @property
     def values(self):
         """Multi-dimensional array of values"""
@@ -43,6 +44,7 @@ class DimensionedArray(Protocol):
 
 
 class AttributeManager(Protocol):
+
     def __getitem__(self, name: str):
         """Get attribute"""
 
@@ -56,6 +58,7 @@ class NexusStructureError(Exception):
 class Attrs:
     """HDF5 attributes.
     """
+
     def __init__(self, attrs: AttributeManager):
         self._attrs = attrs
 
@@ -130,6 +133,7 @@ class Field:
 
     In HDF5 fields are represented as dataset.
     """
+
     def __init__(self, dataset: H5Dataset, dims=None, is_time=None):
         self._dataset = dataset
         self._shape = list(self._dataset.shape)
@@ -277,6 +281,7 @@ class Field:
 class NXobject:
     """Base class for all NeXus groups.
     """
+
     def __init__(self, group: H5Group):
         self._group = group
         self.child_params = {}
@@ -439,6 +444,7 @@ class NXobject:
 
 class NXroot(NXobject):
     """Root of a NeXus file."""
+
     @property
     def nx_class(self) -> type:
         # As an oversight in the NeXus standard and the reference implementation,

--- a/src/scippnexus/nxobject.py
+++ b/src/scippnexus/nxobject.py
@@ -371,29 +371,6 @@ class NXobject:
     def items(self) -> List[Tuple[str, Union[Field, 'NXobject']]]:
         return list(zip(self.keys(), self.values()))
 
-    @functools.lru_cache()
-    def by_nx_class(self) -> Dict[NX_class, Dict[str, 'NXobject']]:
-        classes = {name: [] for name in _nx_class_registry()}
-
-        # TODO implement visititems for NXobject and merge the two blocks
-        def _match_nx_class(_, node):
-            if not hasattr(node, 'shape'):
-                if (nx_class := node.attrs.get('NX_class')) is not None:
-                    if not isinstance(nx_class, str):
-                        nx_class = nx_class.decode('UTF-8')
-                    if nx_class in _nx_class_registry():
-                        classes[nx_class].append(node)
-
-        self._group.visititems(_match_nx_class)
-
-        out = {}
-        for nx_class, groups in classes.items():
-            names = [group.name.split('/')[-1] for group in groups]
-            if len(names) != len(set(names)):  # fall back to full path if duplicate
-                names = [group.name for group in groups]
-            out[NX_class[nx_class]] = {n: _make(g) for n, g in zip(names, groups)}
-        return out
-
     @property
     def nx_class(self) -> NX_class:
         """The value of the NX_class attribute of the group.

--- a/src/scippnexus/nxobject.py
+++ b/src/scippnexus/nxobject.py
@@ -29,6 +29,7 @@ class DimensionedArray(Protocol):
 
     Could be, e.g., a scipp.Variable or a dimple dataclass wrapping a numpy array.
     """
+
     @property
     def values(self):
         """Multi-dimensional array of values"""
@@ -43,6 +44,7 @@ class DimensionedArray(Protocol):
 
 
 class AttributeManager(Protocol):
+
     def __getitem__(self, name: str):
         """Get attribute"""
 
@@ -56,6 +58,7 @@ class NexusStructureError(Exception):
 class Attrs:
     """HDF5 attributes.
     """
+
     def __init__(self, attrs: AttributeManager):
         self._attrs = attrs
 
@@ -130,6 +133,7 @@ class Field:
 
     In HDF5 fields are represented as dataset.
     """
+
     def __init__(self, dataset: H5Dataset, dims=None, is_time=None):
         self._dataset = dataset
         self._shape = list(self._dataset.shape)
@@ -277,6 +281,7 @@ class Field:
 class NXobject:
     """Base class for all NeXus groups.
     """
+
     def __init__(self, group: H5Group):
         self._group = group
         self.child_params = {}
@@ -407,6 +412,7 @@ class NXobject:
 
 class NXroot(NXobject):
     """Root of a NeXus file."""
+
     @property
     def nx_class(self) -> type:
         # As an oversight in the NeXus standard and the reference implementation,

--- a/src/scippnexus/nxobject.py
+++ b/src/scippnexus/nxobject.py
@@ -317,11 +317,11 @@ class NXobject:
         return da
 
     def _get_children_by_nx_class(self, select: type) -> Dict['NXobject']:
-        return {
-            key: value
-            for key, value in self.items()
-            if (nx_class := value.attrs.get('NX_class')) == select.__name__
-        }
+        children = {}
+        for key in self.keys():
+            if (child := self._get_child(key)).attrs.get('NX_class') == select.__name__:
+                children[key] = child
+        return children
 
     def __getitem__(
             self,

--- a/tests/nexus_test.py
+++ b/tests/nexus_test.py
@@ -5,7 +5,7 @@ import h5py
 import numpy as np
 import pytest
 import scipp as sc
-from scippnexus import Field, NXroot, NX_class, NXentry, NXmonitor, NXlog, NXevent_data
+from scippnexus import Field, NXroot, NXentry, NXmonitor, NXlog, NXevent_data
 
 # representative sample of UTF-8 test strings from
 # https://www.w3.org/2001/06/utf-8-test/UTF-8-demo.html
@@ -21,17 +21,17 @@ def nxroot(request):
     """Yield NXroot containing a single NXentry named 'entry'"""
     with h5py.File('dummy.nxs', mode='w', driver="core", backing_store=False) as f:
         root = NXroot(f)
-        root.create_class('entry', NX_class.NXentry)
+        root.create_class('entry', NXentry)
         yield root
 
 
 def test_nxobject_root(nxroot):
-    assert nxroot.nx_class == NX_class.NXroot
+    assert nxroot.nx_class == NXroot
     assert set(nxroot.keys()) == {'entry'}
 
 
 def test_nxobject_create_class_creates_keys(nxroot):
-    nxroot.create_class('log', NX_class.NXlog)
+    nxroot.create_class('log', NXlog)
     assert set(nxroot.keys()) == {'entry', 'log'}
 
 
@@ -40,21 +40,21 @@ def test_nxobject_items(nxroot):
     assert len(items) == 1
     name, entry = items[0]
     assert name == 'entry'
-    entry.create_class('monitor', NX_class.NXmonitor)
-    entry.create_class('log', NX_class.NXlog)
+    entry.create_class('monitor', NXmonitor)
+    entry.create_class('log', NXlog)
     assert {k: v.nx_class
             for k, v in entry.items()} == {
-                'log': NX_class.NXlog,
-                'monitor': NX_class.NXmonitor
+                'log': NXlog,
+                'monitor': NXmonitor
             }
 
 
 def test_nxobject_entry(nxroot):
     entry = nxroot['entry']
-    assert entry.nx_class == NX_class.NXentry
-    entry.create_class('events_0', NX_class.NXevent_data)
-    entry.create_class('events_1', NX_class.NXevent_data)
-    entry.create_class('log', NX_class.NXlog)
+    assert entry.nx_class == NXentry
+    entry.create_class('events_0', NXevent_data)
+    entry.create_class('events_1', NXevent_data)
+    entry.create_class('log', NXlog)
     assert set(entry.keys()) == {'events_0', 'events_1', 'log'}
 
 
@@ -66,10 +66,10 @@ def test_nxobject_log(nxroot):
                           sc.array(dims=['time'], unit='s', values=[4.4, 5.5, 6.6]).to(
                               unit='ns', dtype='int64')
                       })
-    log = nxroot['entry'].create_class('log', NX_class.NXlog)
+    log = nxroot['entry'].create_class('log', NXlog)
     log['value'] = da.data
     log['time'] = da.coords['time'] - sc.epoch(unit='ns')
-    assert log.nx_class == NX_class.NXlog
+    assert log.nx_class == NXlog
     assert sc.identical(log[...], da)
 
 
@@ -81,10 +81,10 @@ def test_nxlog_length_1(nxroot):
             sc.epoch(unit='ns') +
             sc.array(dims=['time'], unit='s', values=[4.4]).to(unit='ns', dtype='int64')
         })
-    log = nxroot['entry'].create_class('log', NX_class.NXlog)
+    log = nxroot['entry'].create_class('log', NXlog)
     log['value'] = da.data
     log['time'] = da.coords['time'] - sc.epoch(unit='ns')
-    assert log.nx_class == NX_class.NXlog
+    assert log.nx_class == NXlog
     assert sc.identical(log[...], da)
 
 
@@ -96,7 +96,7 @@ def test_nxlog_length_1_two_dims_no_time_squeezes_all_dims(nxroot):
             sc.epoch(unit='ns') +
             sc.array(dims=['time'], unit='s', values=[4.4]).to(unit='ns', dtype='int64')
         })
-    log = nxroot['entry'].create_class('log', NX_class.NXlog)
+    log = nxroot['entry'].create_class('log', NXlog)
     log['value'] = da.data
     assert sc.identical(log[...], sc.DataArray(sc.scalar(1.1)))
 
@@ -109,7 +109,7 @@ def test_nxlog_length_1_two_dims_with_time_squeezes_inner_dim(nxroot):
             sc.epoch(unit='ns') +
             sc.array(dims=['time'], unit='s', values=[4.4]).to(unit='ns', dtype='int64')
         })
-    log = nxroot['entry'].create_class('log', NX_class.NXlog)
+    log = nxroot['entry'].create_class('log', NXlog)
     log['value'] = da.data
     log['time'] = da.coords['time'] - sc.epoch(unit='ns')
     assert sc.identical(log[...], da['ignored', 0])
@@ -123,7 +123,7 @@ def test_nxlog_axes_replaces_time_dim(nxroot):
             sc.epoch(unit='ns') +
             sc.array(dims=['time'], unit='s', values=[4.4]).to(unit='ns', dtype='int64')
         })
-    log = nxroot['entry'].create_class('log', NX_class.NXlog)
+    log = nxroot['entry'].create_class('log', NXlog)
     log.attrs['axes'] = ['yy', 'xx']
     log['value'] = da.data
     log['time'] = da.coords['time'] - sc.epoch(unit='ns')
@@ -140,7 +140,7 @@ def test_nxlog_three_dims_with_time_of_length_1(nxroot):
             sc.epoch(unit='ns') +
             sc.array(dims=['time'], unit='s', values=[4.4]).to(unit='ns', dtype='int64')
         })
-    log = nxroot['entry'].create_class('log', NX_class.NXlog)
+    log = nxroot['entry'].create_class('log', NXlog)
     log['value'] = da.data
     log['time'] = da.coords['time'] - sc.epoch(unit='ns')
     loaded = log[...]
@@ -153,15 +153,15 @@ def test_nxlog_three_dims_with_time_of_length_1(nxroot):
 def test_nxlog_with_shape_0(nxroot):
     da = sc.DataArray(sc.ones(dims=['time', 'ignored'], shape=(0, 1)),
                       coords={'time': sc.ones(dims=['time'], shape=(0, ), unit='s')})
-    log = nxroot['entry'].create_class('log', NX_class.NXlog)
+    log = nxroot['entry'].create_class('log', NXlog)
     log['value'] = da.data
     log['time'] = da.coords['time']
     assert sc.identical(log[...], da['ignored', 0])
 
 
 def test_nxobject_event_data(nxroot):
-    event_data = nxroot['entry'].create_class('events_0', NX_class.NXevent_data)
-    assert event_data.nx_class == NX_class.NXevent_data
+    event_data = nxroot['entry'].create_class('events_0', NXevent_data)
+    assert event_data.nx_class == NXevent_data
 
 
 def test_nxobject_getting_item_that_does_not_exists_raises_KeyError(nxroot):
@@ -170,9 +170,9 @@ def test_nxobject_getting_item_that_does_not_exists_raises_KeyError(nxroot):
 
 
 def test_nxobject_name_property_is_full_path(nxroot):
-    nxroot.create_class('monitor', NX_class.NXmonitor)
-    nxroot['entry'].create_class('log', NX_class.NXlog)
-    nxroot['entry'].create_class('events_0', NX_class.NXevent_data)
+    nxroot.create_class('monitor', NXmonitor)
+    nxroot['entry'].create_class('log', NXlog)
+    nxroot['entry'].create_class('events_0', NXevent_data)
     assert nxroot.name == '/'
     assert nxroot['monitor'].name == '/monitor'
     assert nxroot['entry'].name == '/entry'
@@ -181,16 +181,16 @@ def test_nxobject_name_property_is_full_path(nxroot):
 
 
 def test_nxobject_grandchild_can_be_accessed_using_path(nxroot):
-    nxroot['entry'].create_class('log', NX_class.NXlog)
+    nxroot['entry'].create_class('log', NXlog)
     assert nxroot['entry/log'].name == '/entry/log'
     assert nxroot['/entry/log'].name == '/entry/log'
 
 
 def test_nxobject_getitem_by_class(nxroot):
-    nxroot.create_class('monitor', NX_class.NXmonitor)
-    nxroot['entry'].create_class('log', NX_class.NXlog)
-    nxroot['entry'].create_class('events_0', NX_class.NXevent_data)
-    nxroot['entry'].create_class('events_1', NX_class.NXevent_data)
+    nxroot.create_class('monitor', NXmonitor)
+    nxroot['entry'].create_class('log', NXlog)
+    nxroot['entry'].create_class('events_0', NXevent_data)
+    nxroot['entry'].create_class('events_1', NXevent_data)
     assert list(nxroot[NXentry]) == ['entry']
     assert list(nxroot[NXmonitor]) == ['monitor']
     assert list(nxroot['entry'][NXmonitor]) == []  # not nested
@@ -200,14 +200,14 @@ def test_nxobject_getitem_by_class(nxroot):
 
 
 def test_nxobject_dataset_items_are_returned_as_Field(nxroot):
-    events = nxroot['entry'].create_class('events_0', NX_class.NXevent_data)
+    events = nxroot['entry'].create_class('events_0', NXevent_data)
     events['event_time_offset'] = sc.arange('event', 5)
     field = nxroot['entry/events_0/event_time_offset']
     assert isinstance(field, Field)
 
 
 def test_field_properties(nxroot):
-    events = nxroot['entry'].create_class('events_0', NX_class.NXevent_data)
+    events = nxroot['entry'].create_class('events_0', NXevent_data)
     events['event_time_offset'] = sc.arange('event', 6, dtype='int64', unit='ns')
     field = nxroot['entry/events_0/event_time_offset']
     assert field.dtype == 'int64'
@@ -217,7 +217,7 @@ def test_field_properties(nxroot):
 
 
 def test_field_dim_labels(nxroot):
-    events = nxroot['entry'].create_class('events_0', NX_class.NXevent_data)
+    events = nxroot['entry'].create_class('events_0', NXevent_data)
     events['event_time_offset'] = sc.arange('ignored', 2)
     events['event_time_zero'] = sc.arange('ignored', 2)
     events['event_index'] = sc.arange('ignored', 2)
@@ -227,7 +227,7 @@ def test_field_dim_labels(nxroot):
     assert event_data['event_time_zero'].dims == ['pulse']
     assert event_data['event_index'].dims == ['pulse']
     assert event_data['event_id'].dims == ['event']
-    log = nxroot['entry'].create_class('log', NX_class.NXlog)
+    log = nxroot['entry'].create_class('log', NXlog)
     log['value'] = sc.arange('ignored', 2)
     log['time'] = sc.arange('ignored', 2)
     assert log['time'].dims == ['time']
@@ -235,7 +235,7 @@ def test_field_dim_labels(nxroot):
 
 
 def test_field_unit_is_none_if_no_units_attribute(nxroot):
-    log = nxroot.create_class('log', NX_class.NXlog)
+    log = nxroot.create_class('log', NXlog)
     log['value'] = sc.arange('ignored', 2, unit=None)
     log['time'] = sc.arange('ignored', 2)
     assert log.unit is None
@@ -345,7 +345,7 @@ def create_event_data_ids_1234(group):
 
 
 def test_negative_event_index_converted_to_num_event(nxroot):
-    event_data = nxroot['entry'].create_class('events_0', NX_class.NXevent_data)
+    event_data = nxroot['entry'].create_class('events_0', NXevent_data)
     create_event_data_ids_1234(event_data)
     events = nxroot['entry/events_0'][...]
     assert events.bins.size().values[2] == 3
@@ -353,7 +353,7 @@ def test_negative_event_index_converted_to_num_event(nxroot):
 
 
 def test_bad_event_index_raises_IndexError(nxroot):
-    event_data = nxroot['entry'].create_class('events_0', NX_class.NXevent_data)
+    event_data = nxroot['entry'].create_class('events_0', NXevent_data)
     event_data['event_id'] = sc.array(dims=[''], unit=None, values=[1, 2, 4, 1, 2])
     event_data['event_time_offset'] = sc.array(dims=[''], unit='s', values=[0, 0, 0, 0])
     event_data['event_time_zero'] = sc.array(dims=[''], unit='s', values=[1, 2, 3, 4])
@@ -371,7 +371,7 @@ def create_event_data_without_event_id(group):
 
 
 def test_event_data_without_event_id_can_be_loaded(nxroot):
-    event_data = nxroot['entry'].create_class('events_0', NX_class.NXevent_data)
+    event_data = nxroot['entry'].create_class('events_0', NXevent_data)
     create_event_data_without_event_id(event_data)
     da = event_data[...]
     assert len(da.bins.coords) == 1
@@ -379,7 +379,7 @@ def test_event_data_without_event_id_can_be_loaded(nxroot):
 
 
 def test_event_mode_monitor_without_event_id_can_be_loaded(nxroot):
-    monitor = nxroot['entry'].create_class('monitor', NX_class.NXmonitor)
+    monitor = nxroot['entry'].create_class('monitor', NXmonitor)
     create_event_data_without_event_id(monitor)
     da = monitor[...]
     assert len(da.bins.coords) == 1

--- a/tests/nexus_test.py
+++ b/tests/nexus_test.py
@@ -5,7 +5,7 @@ import h5py
 import numpy as np
 import pytest
 import scipp as sc
-from scippnexus import Field, NXroot, NX_class
+from scippnexus import Field, NXroot, NX_class, NXentry, NXmonitor, NXlog, NXevent_data
 
 # representative sample of UTF-8 test strings from
 # https://www.w3.org/2001/06/utf-8-test/UTF-8-demo.html
@@ -186,28 +186,17 @@ def test_nxobject_grandchild_can_be_accessed_using_path(nxroot):
     assert nxroot['/entry/log'].name == '/entry/log'
 
 
-def test_nxobject_by_nx_class_of_root_contains_everything(nxroot):
+def test_nxobject_getitem_by_class(nxroot):
     nxroot.create_class('monitor', NX_class.NXmonitor)
     nxroot['entry'].create_class('log', NX_class.NXlog)
     nxroot['entry'].create_class('events_0', NX_class.NXevent_data)
     nxroot['entry'].create_class('events_1', NX_class.NXevent_data)
-    classes = nxroot.by_nx_class()
-    assert list(classes[NX_class.NXentry]) == ['entry']
-    assert list(classes[NX_class.NXmonitor]) == ['monitor']
-    assert list(classes[NX_class.NXlog]) == ['log']
-    assert set(classes[NX_class.NXevent_data]) == {'events_0', 'events_1'}
-
-
-def test_nxobject_by_nx_class_contains_only_children(nxroot):
-    nxroot.create_class('monitor', NX_class.NXmonitor)
-    nxroot['entry'].create_class('log', NX_class.NXlog)
-    nxroot['entry'].create_class('events_0', NX_class.NXevent_data)
-    nxroot['entry'].create_class('events_1', NX_class.NXevent_data)
-    classes = nxroot['entry'].by_nx_class()
-    assert list(classes[NX_class.NXentry]) == []
-    assert list(classes[NX_class.NXmonitor]) == []
-    assert list(classes[NX_class.NXlog]) == ['log']
-    assert set(classes[NX_class.NXevent_data]) == set(['events_0', 'events_1'])
+    assert list(nxroot[NXentry]) == ['entry']
+    assert list(nxroot[NXmonitor]) == ['monitor']
+    assert list(nxroot['entry'][NXmonitor]) == []  # not nested
+    assert list(nxroot[NXlog]) == []  # nested
+    assert list(nxroot['entry'][NXlog]) == ['log']
+    assert set(nxroot['entry'][NXevent_data]) == {'events_0', 'events_1'}
 
 
 def test_nxobject_dataset_items_are_returned_as_Field(nxroot):

--- a/tests/nxdetector_test.py
+++ b/tests/nxdetector_test.py
@@ -1,7 +1,7 @@
 import h5py
 import numpy as np
 import scipp as sc
-from scippnexus import NXroot, NX_class, NexusStructureError
+from scippnexus import NXroot, NXentry, NXdetector, NXevent_data, NexusStructureError
 import pytest
 
 
@@ -10,13 +10,13 @@ def nxroot(request):
     """Yield NXroot containing a single NXentry named 'entry'"""
     with h5py.File('dummy.nxs', mode='w', driver="core", backing_store=False) as f:
         root = NXroot(f)
-        root.create_class('entry', NX_class.NXentry)
+        root.create_class('entry', NXentry)
         yield root
 
 
 def test_raises_if_no_data_found(nxroot):
     detector_numbers = sc.array(dims=[''], unit=None, values=np.array([1, 2, 3, 4]))
-    detector = nxroot.create_class('detector0', NX_class.NXdetector)
+    detector = nxroot.create_class('detector0', NXdetector)
     detector.create_field('detector_numbers', detector_numbers)
     with pytest.raises(KeyError):
         detector[...]
@@ -25,7 +25,7 @@ def test_raises_if_no_data_found(nxroot):
 def test_loads_events_when_data_and_events_found(nxroot):
     detector_number = sc.array(dims=[''], unit=None, values=np.array([1, 2]))
     data = sc.ones(dims=['xx'], shape=[2])
-    detector = nxroot.create_class('detector0', NX_class.NXdetector)
+    detector = nxroot.create_class('detector0', NXdetector)
     detector.create_field('detector_number', detector_number)
     detector.create_field('data', data)
     assert detector[...].bins is None
@@ -44,7 +44,7 @@ def detector_numbers_xx_yy_1234():
 def test_loads_data_without_coords(nxroot):
     da = sc.DataArray(sc.array(dims=['xx', 'yy'], values=[[1.1, 2.2], [3.3, 4.4]]))
     da.coords['detector_numbers'] = detector_numbers_xx_yy_1234()
-    detector = nxroot.create_class('detector0', NX_class.NXdetector)
+    detector = nxroot.create_class('detector0', NXdetector)
     detector.create_field('detector_numbers', da.coords['detector_numbers'])
     detector.create_field('data', da.data)
     assert sc.identical(detector[...], da.rename_dims({'xx': 'dim_0', 'yy': 'dim_1'}))
@@ -55,7 +55,7 @@ def test_loads_data_without_coords(nxroot):
 def test_detector_number_key_alias(nxroot, detector_number_key):
     da = sc.DataArray(sc.array(dims=['xx', 'yy'], values=[[1.1, 2.2], [3.3, 4.4]]))
     da.coords[detector_number_key] = detector_numbers_xx_yy_1234()
-    detector = nxroot.create_class('detector0', NX_class.NXdetector)
+    detector = nxroot.create_class('detector0', NXdetector)
     detector.create_field(detector_number_key, da.coords[detector_number_key])
     detector.create_field('data', da.data)
     assert sc.identical(detector[...], da.rename_dims({'xx': 'dim_0', 'yy': 'dim_1'}))
@@ -64,7 +64,7 @@ def test_detector_number_key_alias(nxroot, detector_number_key):
 def test_select_events_raises_if_detector_contains_data(nxroot):
     da = sc.DataArray(sc.array(dims=['xx', 'yy'], values=[[1.1, 2.2], [3.3, 4.4]]))
     da.coords['detector_numbers'] = detector_numbers_xx_yy_1234()
-    detector = nxroot.create_class('detector0', NX_class.NXdetector)
+    detector = nxroot.create_class('detector0', NXdetector)
     detector.create_field('detector_numbers', da.coords['detector_numbers'])
     detector.create_field('data', da.data)
     with pytest.raises(NexusStructureError):
@@ -76,7 +76,7 @@ def test_loads_data_with_coords(nxroot):
         sc.array(dims=['xx', 'yy'], unit='K', values=[[1.1, 2.2], [3.3, 4.4]]))
     da.coords['detector_numbers'] = detector_numbers_xx_yy_1234()
     da.coords['xx'] = sc.array(dims=['xx'], unit='m', values=[0.1, 0.2])
-    detector = nxroot.create_class('detector0', NX_class.NXdetector)
+    detector = nxroot.create_class('detector0', NXdetector)
     detector.create_field('detector_numbers', da.coords['detector_numbers'])
     detector.create_field('xx', da.coords['xx'])
     detector.create_field('data', da.data)
@@ -97,7 +97,7 @@ def test_slicing_works_as_in_scipp(nxroot):
     da.coords['2d_edges'] = sc.array(dims=['yy', 'xx'],
                                      unit='m',
                                      values=[[1, 2, 3], [4, 5, 6], [7, 8, 9]])
-    detector = nxroot.create_class('detector0', NX_class.NXdetector)
+    detector = nxroot.create_class('detector0', NXdetector)
     detector.create_field('detector_numbers', da.coords['detector_numbers'])
     detector.create_field('xx', da.coords['xx'])
     detector.create_field('xx2', da.coords['xx2'])
@@ -129,9 +129,9 @@ def create_event_data_ids_1234(group):
 
 def test_loads_event_data_mapped_to_detector_numbers_based_on_their_event_id(nxroot):
     detector_numbers = sc.array(dims=[''], unit=None, values=np.array([1, 2, 3, 4]))
-    detector = nxroot.create_class('detector0', NX_class.NXdetector)
+    detector = nxroot.create_class('detector0', NXdetector)
     detector.create_field('detector_number', detector_numbers)
-    create_event_data_ids_1234(detector.create_class('events', NX_class.NXevent_data))
+    create_event_data_ids_1234(detector.create_class('events', NXevent_data))
     assert detector.dims == ['dim_0']
     assert detector.shape == [4]
     loaded = detector[...]
@@ -143,9 +143,9 @@ def test_loads_event_data_mapped_to_detector_numbers_based_on_their_event_id(nxr
 
 
 def test_loads_event_data_with_0d_detector_numbers(nxroot):
-    detector = nxroot.create_class('detector0', NX_class.NXdetector)
+    detector = nxroot.create_class('detector0', NXdetector)
     detector.create_field('detector_number', sc.index(1, dtype='int64'))
-    create_event_data_ids_1234(detector.create_class('events', NX_class.NXevent_data))
+    create_event_data_ids_1234(detector.create_class('events', NXevent_data))
     assert detector.dims == []
     assert detector.shape == []
     loaded = detector[...]
@@ -153,9 +153,9 @@ def test_loads_event_data_with_0d_detector_numbers(nxroot):
 
 
 def test_loads_event_data_with_2d_detector_numbers(nxroot):
-    detector = nxroot.create_class('detector0', NX_class.NXdetector)
+    detector = nxroot.create_class('detector0', NXdetector)
     detector.create_field('detector_number', detector_numbers_xx_yy_1234())
-    create_event_data_ids_1234(detector.create_class('events', NX_class.NXevent_data))
+    create_event_data_ids_1234(detector.create_class('events', NXevent_data))
     assert detector.dims == ['dim_0', 'dim_1']
     assert detector.shape == [2, 2]
     loaded = detector[...]
@@ -168,9 +168,9 @@ def test_loads_event_data_with_2d_detector_numbers(nxroot):
 
 
 def test_select_events_slices_underlying_event_data(nxroot):
-    detector = nxroot.create_class('detector0', NX_class.NXdetector)
+    detector = nxroot.create_class('detector0', NXdetector)
     detector.create_field('detector_number', detector_numbers_xx_yy_1234())
-    create_event_data_ids_1234(detector.create_class('events', NX_class.NXevent_data))
+    create_event_data_ids_1234(detector.create_class('events', NXevent_data))
     assert sc.identical(
         detector.select_events['pulse', :2][...].bins.size().data,
         sc.array(dims=['dim_0', 'dim_1'],
@@ -198,9 +198,9 @@ def test_select_events_slices_underlying_event_data(nxroot):
 
 
 def test_select_events_slice_does_not_affect_original_detector(nxroot):
-    detector = nxroot.create_class('detector0', NX_class.NXdetector)
+    detector = nxroot.create_class('detector0', NXdetector)
     detector.create_field('detector_number', detector_numbers_xx_yy_1234())
-    create_event_data_ids_1234(detector.create_class('events', NX_class.NXevent_data))
+    create_event_data_ids_1234(detector.create_class('events', NXevent_data))
     detector.select_events['pulse', 0][...]
     assert sc.identical(
         detector[...].bins.size().data,
@@ -212,8 +212,8 @@ def test_select_events_slice_does_not_affect_original_detector(nxroot):
 
 def test_loading_event_data_creates_automatic_detector_numbers_if_not_present_in_file(
         nxroot):
-    detector = nxroot.create_class('detector0', NX_class.NXdetector)
-    create_event_data_ids_1234(detector.create_class('events', NX_class.NXevent_data))
+    detector = nxroot.create_class('detector0', NXdetector)
+    create_event_data_ids_1234(detector.create_class('events', NXevent_data))
     assert detector.dims == ['detector_number']
     with pytest.raises(NexusStructureError):
         detector.shape
@@ -228,8 +228,8 @@ def test_loading_event_data_creates_automatic_detector_numbers_if_not_present_in
 
 def test_loading_event_data_with_selection_and_automatic_detector_numbers_raises(
         nxroot):
-    detector = nxroot.create_class('detector0', NX_class.NXdetector)
-    create_event_data_ids_1234(detector.create_class('events', NX_class.NXevent_data))
+    detector = nxroot.create_class('detector0', NXdetector)
+    create_event_data_ids_1234(detector.create_class('events', NXevent_data))
     assert detector.dims == ['detector_number']
     with pytest.raises(NexusStructureError):
         detector['detector_number', 0]
@@ -237,8 +237,8 @@ def test_loading_event_data_with_selection_and_automatic_detector_numbers_raises
 
 def test_loading_event_data_with_full_selection_and_automatic_detector_numbers_works(
         nxroot):
-    detector = nxroot.create_class('detector0', NX_class.NXdetector)
-    create_event_data_ids_1234(detector.create_class('events', NX_class.NXevent_data))
+    detector = nxroot.create_class('detector0', NXdetector)
+    create_event_data_ids_1234(detector.create_class('events', NXevent_data))
     assert detector.dims == ['detector_number']
     assert tuple(detector[...].shape) == (4, )
     assert tuple(detector[()].shape) == (4, )
@@ -246,18 +246,17 @@ def test_loading_event_data_with_full_selection_and_automatic_detector_numbers_w
 
 def test_event_data_field_dims_labels(nxroot):
     detector_numbers = sc.array(dims=[''], unit=None, values=np.array([1, 2, 3, 4]))
-    detector = nxroot.create_class('detector0', NX_class.NXdetector)
+    detector = nxroot.create_class('detector0', NXdetector)
     detector.create_field('detector_number', detector_numbers)
-    create_event_data_ids_1234(detector.create_class('events', NX_class.NXevent_data))
+    create_event_data_ids_1234(detector.create_class('events', NXevent_data))
     assert detector['detector_number'].dims == ['dim_0']
 
 
 def test_nxevent_data_selection_yields_correct_pulses(nxroot):
-    detector = nxroot.create_class('detector0', NX_class.NXdetector)
-    create_event_data_ids_1234(detector.create_class('events', NX_class.NXevent_data))
+    detector = nxroot.create_class('detector0', NXdetector)
+    create_event_data_ids_1234(detector.create_class('events', NXevent_data))
 
     class Load:
-
         def __getitem__(self, select=...):
             da = detector['events'][select]
             return da.bins.size().values

--- a/tests/nxdetector_test.py
+++ b/tests/nxdetector_test.py
@@ -257,6 +257,7 @@ def test_nxevent_data_selection_yields_correct_pulses(nxroot):
     create_event_data_ids_1234(detector.create_class('events', NXevent_data))
 
     class Load:
+
         def __getitem__(self, select=...):
             da = detector['events'][select]
             return da.bins.size().values

--- a/tests/nxmonitor_test.py
+++ b/tests/nxmonitor_test.py
@@ -1,6 +1,6 @@
 import h5py
 import scipp as sc
-from scippnexus import NXroot, NX_class
+from scippnexus import NXroot, NXentry, NXmonitor, NXevent_data
 import pytest
 
 
@@ -9,13 +9,13 @@ def nxroot(request):
     """Yield NXroot containing a single NXentry named 'entry'"""
     with h5py.File('dummy.nxs', mode='w', driver="core", backing_store=False) as f:
         root = NXroot(f)
-        root.create_class('entry', NX_class.NXentry)
+        root.create_class('entry', NXentry)
         yield root
 
 
 def test_dense_monitor(nxroot):
-    monitor = nxroot['entry'].create_class('monitor', NX_class.NXmonitor)
-    assert monitor.nx_class == NX_class.NXmonitor
+    monitor = nxroot['entry'].create_class('monitor', NXmonitor)
+    assert monitor.nx_class == NXmonitor
     da = sc.DataArray(
         sc.array(dims=['time_of_flight'], values=[1.0]),
         coords={'time_of_flight': sc.array(dims=['time_of_flight'], values=[1.0])})
@@ -36,7 +36,7 @@ def create_event_data_no_ids(group):
 
 
 def test_loads_event_data_in_current_group(nxroot):
-    monitor = nxroot.create_class('monitor1', NX_class.NXmonitor)
+    monitor = nxroot.create_class('monitor1', NXmonitor)
     create_event_data_no_ids(monitor)
     assert monitor.dims == ['pulse']
     assert monitor.shape == [4]
@@ -47,8 +47,8 @@ def test_loads_event_data_in_current_group(nxroot):
 
 
 def test_loads_event_data_in_child_group(nxroot):
-    monitor = nxroot.create_class('monitor1', NX_class.NXmonitor)
-    create_event_data_no_ids(monitor.create_class('events', NX_class.NXevent_data))
+    monitor = nxroot.create_class('monitor1', NXmonitor)
+    create_event_data_no_ids(monitor.create_class('events', NXevent_data))
     assert monitor.dims == ['pulse']
     assert monitor.shape == [4]
     loaded = monitor[...]


### PR DESCRIPTION
This is part of an effort to improve the overall interface. #45 experiments with providing properties for accessing specific children based on their class, without requiring knowledge of their name. As reported in https://github.com/scipp/scippneutron/issues/359#issuecomment-1223869619 this has some issues. In particular the singular/plural "overloading" does not appear to be a workable solution. Instead we will:

- Provide attributes for accessing unique child, e.g., `file.entry.instrument` (this will be in a follow-up PR, basically a modification of #45).
- Access "all (direct) children of certain class" by providing `__getitem__` that accepts the NX_class as a key (this PR).

Additional changes here:
- The enum `NX_class` is removed. I have always felt that it was cumbersome to use. The second bullet above means users will need to use such keys more (instead of group names). Therefore we switch to using the classes as keys.
- Remove `by_nx_class`, which had a number of problems (see commit message). This is used in `scippnexus.load_nexus`, which will need refactoring.