### PR TITLE
Load all content from NXsource, NXsample, and NXdisk_chopper

### DIFF
--- a/docs/about/release-notes.rst
+++ b/docs/about/release-notes.rst
@@ -28,8 +28,27 @@ Release Notes
    Neil Vaytet :sup:`a`\ ,
    and Jan-Lukas Wynen :sup:`a`
 
-v0.2.1 (Unreleased)
+v0.3.0 (Unreleased)
 -------------------
+
+Features
+~~~~~~~~
+
+* :class:`scippnexus.NXsource`, :class:`scippnexus.NXsample`, and :class:`scippnexus.NXdisk_chopper` now load all entries `#54 <https://github.com/scipp/scipp/pull/54>`_.
+
+Breaking changes
+~~~~~~~~~~~~~~~~
+
+* :class:`scippnexus.NXsource`, :class:`scippnexus.NXsample`, and :class:`scippnexus.NXdisk_chopper` return a ``dict`` instead of ``scipp.Dataset`` `#54 <https://github.com/scipp/scipp/pull/54>`_.
+
+Bugfixes
+~~~~~~~~
+
+Deprecations
+~~~~~~~~~~~~
+
+v0.2.1 (August 2022)
+--------------------
 
 Features
 ~~~~~~~~

--- a/docs/user-guide/nexus-classes.ipynb
+++ b/docs/user-guide/nexus-classes.ipynb
@@ -29,15 +29,15 @@
     ":--- |:--- |:--- |:---\n",
     "[NXdata](../generated/classes/scippnexus.NXdata.rst) | scipp.DataArray | [example below](#NXdata) | [link](https://manual.nexusformat.org/classes/base_classes/NXdata.html)\n",
     "[NXdetector](../generated/classes/scippnexus.NXdetector.rst) | scipp.DataArray | [example below](#NXdetector) | [link](https://manual.nexusformat.org/classes/base_classes/NXdetector.html)\n",
-    "[NXdisk_chopper](../generated/classes/scippnexus.NXdisk_chopper.rst) | scipp.Dataset |very incomplete support| [link](https://manual.nexusformat.org/classes/base_classes/NXdisk_chopper.html)\n",
+    "[NXdisk_chopper](../generated/classes/scippnexus.NXdisk_chopper.rst) | dict || [link](https://manual.nexusformat.org/classes/base_classes/NXdisk_chopper.html)\n",
     "[NXentry](../generated/classes/scippnexus.NXentry.rst) | &mdash; | [generic group-like](#Base-class:-NXobject) | [link](https://manual.nexusformat.org/classes/base_classes/NXentry.html)\n",
     "[NXevent_data](../generated/classes/scippnexus.NXevent_data.rst) | scipp.DataArray | [example below](#NXevent_data) | [link](https://manual.nexusformat.org/classes/base_classes/NXevent_data.html)\n",
     "[NXinstrument](../generated/classes/scippnexus.NXinstrument.rst) | &mdash; | [generic group-like](#Base-class:-NXobject) | [link](https://manual.nexusformat.org/classes/base_classes/NXinstrument.html)\n",
     "[NXlog](../generated/classes/scippnexus.NXlog.rst) | scipp.DataArray | [example below](#NXlog) | [link](https://manual.nexusformat.org/classes/base_classes/NXlog.html)\n",
     "[NXmonitor](../generated/classes/scippnexus.NXmonitor.rst) | scipp.DataArray | [example below](#NXmonitor) | [link](https://manual.nexusformat.org/classes/base_classes/NXmonitor.html)\n",
     "[NXroot](../generated/classes/scippnexus.NXroot.rst) | &mdash; | [generic group-like](#Base-class:-NXobject) | [link](https://manual.nexusformat.org/classes/base_classes/NXroot.html)\n",
-    "[NXsample](../generated/classes/scippnexus.NXsample.rst) | scipp.Dataset |very incomplete support| [link](https://manual.nexusformat.org/classes/base_classes/NXsample.html)\n",
-    "[NXsource](../generated/classes/scippnexus.NXsource.rst) | scipp.Dataset |very incomplete support| [link](https://manual.nexusformat.org/classes/base_classes/NXsource.html)\n",
+    "[NXsample](../generated/classes/scippnexus.NXsample.rst) | dict || [link](https://manual.nexusformat.org/classes/base_classes/NXsample.html)\n",
+    "[NXsource](../generated/classes/scippnexus.NXsource.rst) | dict || [link](https://manual.nexusformat.org/classes/base_classes/NXsource.html)\n",
     "[NXtransformations](../generated/classes/scippnexus.NXtransformations.rst) | &mdash; | [generic group-like](#Base-class:-NXobject) | [link](https://manual.nexusformat.org/classes/base_classes/NXtransformations.html)"
    ]
   },

--- a/src/scippnexus/docs/our-interpretation-of-the-nexus-format.md
+++ b/src/scippnexus/docs/our-interpretation-of-the-nexus-format.md
@@ -47,6 +47,12 @@ More concretely this means that, e.g., for loading an `NXdetector` from a NH, th
 
 If the above yields no more than one item, the group can be loaded.
 
+## NXlog as field replacement
+
+According to TR [NXlog](https://manual.nexusformat.org/classes/base_classes/NXlog.html) can replace any field, if the field is time dependent.
+This is typically used within [NXsource](https://manual.nexusformat.org/classes/base_classes/NXsource.html), [NXsample](https://manual.nexusformat.org/classes/base_classes/NXsample.html), [NXdisk_chopper](https://manual.nexusformat.org/classes/base_classes/NXdisk_chopper.html), and others.
+Another example is [NXtransformations](https://manual.nexusformat.org/classes/base_classes/NXtransformations.html) for time-dependent positions of beamline components.
+
 ## Datetime fields
 
 HDF5 does not support storing date and time information such as `np.datetime64`.
@@ -64,11 +70,11 @@ For [NXdetector](https://manual.nexusformat.org/classes/base_classes/NXdetector.
 Since what is recorded in `NXdetector` may not actually be time-of-flight, in practice this coordinate may be named differently, e.g., `time_offset`.
 Therefore, we assume that this is valid in general, i.e., also for other axis values (axis tick labels) that may be defined using the [`axes` attribute](https://manual.nexusformat.org/classes/base_classes/NXdata.html#nxdata-axes-attribute).
 
-According to TR this is also used frequently in some fields/applications of [NX_data](https://manual.nexusformat.org/classes/base_classes/NX_data.html).
+According to TR this is also used frequently in some fields/applications of [NXdata](https://manual.nexusformat.org/classes/base_classes/NXdata.html).
 
 ## Missing axis labels
 
-[NX_data](https://manual.nexusformat.org/classes/base_classes/NX_data.html) uses the [`axes` attribute](https://manual.nexusformat.org/classes/base_classes/NXdata.html#nxdata-axes-attribute) to define the names of fields that store coordinates for axes.
+[NXdata](https://manual.nexusformat.org/classes/base_classes/NXdata.html) uses the [`axes` attribute](https://manual.nexusformat.org/classes/base_classes/NXdata.html#nxdata-axes-attribute) to define the names of fields that store coordinates for axes.
 There is a legacy mechanism where the signal field has an [`axes` attribute](https://manual.nexusformat.org/classes/base_classes/NXdata.html#nxdata-data-axes-attribute) and this should not be used according to the NF.
 
 The `axes` attribute uses `'.'` to define an axis without values, i.e., without a field.

--- a/src/scippnexus/leaf.py
+++ b/src/scippnexus/leaf.py
@@ -1,0 +1,25 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright (c) 2022 Scipp contributors (https://github.com/scipp)
+# @author Simon Heybrock
+from typing import Dict, Union
+import scipp as sc
+from .nxobject import NXobject, ScippIndex
+from ._common import to_plain_index
+
+
+class Leaf(NXobject):
+    """Base class for "leaf" groups than can be loaded as a dict.
+    """
+
+    def _getitem(self,
+                 select: ScippIndex) -> Dict[str, Union[sc.Variable, sc.DataArray]]:
+        from .nexus_classes import NXtransformations
+        index = to_plain_index([], select)
+        if index != tuple():
+            raise ValueError("Cannot select slice when loading NXsource")
+        content = {}
+        for key, obj in self.items():
+            if key == 'depends_on' or isinstance(obj, NXtransformations):
+                continue
+            content[key] = obj[()]
+        return content

--- a/src/scippnexus/nxdisk_chopper.py
+++ b/src/scippnexus/nxdisk_chopper.py
@@ -1,27 +1,9 @@
 # SPDX-License-Identifier: BSD-3-Clause
 # Copyright (c) 2022 Scipp contributors (https://github.com/scipp)
 # @author Simon Heybrock
-import scipp as sc
-from .nxobject import NXobject, ScippIndex
+from .leaf import Leaf
 
 
-class NXdisk_chopper(NXobject):
-    """Disk chopper information, can be read as a dataset.
-
-    Currently only the 'distance' and 'rotation_speed' fields are loaded.
+class NXdisk_chopper(Leaf):
+    """Disk chopper information, can be read as a dict.
     """
-
-    @property
-    def shape(self):
-        return []
-
-    @property
-    def dims(self):
-        return []
-
-    def _getitem(self, select: ScippIndex) -> sc.Dataset:
-        ds = sc.Dataset()
-        for name in ['distance', 'rotation_speed']:
-            if (field := self.get(name)) is not None:
-                ds[name] = field[select]
-        return ds

--- a/src/scippnexus/nxobject.py
+++ b/src/scippnexus/nxobject.py
@@ -311,7 +311,11 @@ class NXobject:
                 return _make(item)
         da = self._getitem(name)
         if (t := self.depends_on) is not None:
-            da.coords['depends_on'] = t if isinstance(t, sc.Variable) else sc.scalar(t)
+            if isinstance(da, dict):
+                da['depends_on'] = t
+            else:
+                da.coords['depends_on'] = t if isinstance(t,
+                                                          sc.Variable) else sc.scalar(t)
         return da
 
     def _get_children_by_nx_class(self, select: type) -> Dict[str, 'NXobject']:

--- a/src/scippnexus/nxsource.py
+++ b/src/scippnexus/nxsource.py
@@ -1,30 +1,9 @@
 # SPDX-License-Identifier: BSD-3-Clause
 # Copyright (c) 2022 Scipp contributors (https://github.com/scipp)
 # @author Simon Heybrock
-import scipp as sc
-from ._common import to_plain_index
-from .nxobject import NXobject, ScippIndex
+from .leaf import Leaf
 
 
-class NXsource(NXobject):
-    """Source information, can be read as a dataset.
-
-    Currently only the 'distance' field is loaded.
+class NXsource(Leaf):
+    """Source information, can be read as a dict.
     """
-
-    @property
-    def shape(self):
-        return []
-
-    @property
-    def dims(self):
-        return []
-
-    def _getitem(self, select: ScippIndex) -> sc.Dataset:
-        index = to_plain_index([], select)
-        if index != tuple():
-            raise ValueError("Cannot select slice when loading NXsource")
-        ds = sc.Dataset()
-        if 'distance' in self:
-            ds['distance'] = self['distance'][()]
-        return ds


### PR DESCRIPTION
Based on a chat with TR: Apparently NXlog groups are meant for replacing arbitrary fields. That is, instead of loading a list of NXlog groups from somewhere in the file, we should instead simply load possible parent groups in a way that supports this.

This implies in particular that groups such as NXsample may contain, e.g., a `temperature` that is not a 0-D field, but yields a DataArray. We can thus not assume the NXsample can be represented as `scipp.Dataset`. I am therefore switching to `dict` here. Another alternative would have been wrapping in scalar variables, but I do not see an advantage on this level.