### PR TITLE
Use list instead of tuple of classes in __getitem__

### DIFF
--- a/docs/about/release-notes.rst
+++ b/docs/about/release-notes.rst
@@ -36,7 +36,7 @@ Features
 
 * :class:`scippnexus.NXsource`, :class:`scippnexus.NXsample`, and :class:`scippnexus.NXdisk_chopper` now load all entries `#54 <https://github.com/scipp/scipp/pull/54>`_.
 * :meth:`scippnexus.NXobject.__getitem__` now also accepts :class:`scippnexus.Field` as key and returns all direct children that are NeXus fields, i.e., HDF5 datasets (not groups) `#55 <https://github.com/scipp/scipp/pull/55>`_.
-* :meth:`scippnexus.NXobject.__getitem__` now also accepts tuples of classes for selecting multiple child classes `#55 <https://github.com/scipp/scipp/pull/55>`_.
+* :meth:`scippnexus.NXobject.__getitem__` now also accepts a list of classes for selecting multiple child classes `#55 <https://github.com/scipp/scipp/pull/55>`_.
 
 Breaking changes
 ~~~~~~~~~~~~~~~~

--- a/src/scippnexus/nxobject.py
+++ b/src/scippnexus/nxobject.py
@@ -320,8 +320,9 @@ class NXobject:
 
     def _get_children_by_nx_class(
             self, select: Union[type,
-                                Tuple[type]]) -> Dict[str, Union['NXobject', Field]]:
+                                List[type]]) -> Dict[str, Union['NXobject', Field]]:
         children = {}
+        select = tuple(select) if isinstance(select, list) else select
         for key in self.keys():
             if issubclass(type(child := self._get_child(key)), select):
                 children[key] = child
@@ -368,7 +369,7 @@ class NXobject:
         def isclass(x):
             return inspect.isclass(x) and issubclass(x, (Field, NXobject))
 
-        if isclass(name) or (isinstance(name, tuple) and len(name)
+        if isclass(name) or (isinstance(name, list) and len(name)
                              and all(isclass(x) for x in name)):
             return self._get_children_by_nx_class(name)
         return self._get_child(name, use_field_dims=True)

--- a/tests/nexus_test.py
+++ b/tests/nexus_test.py
@@ -215,14 +215,14 @@ def test_nxobject_getitem_by_class_get_fields(nxroot):
     assert set(nxroot['entry'][Field]) == {'field1', 'field2'}
 
 
-def test_nxobject_getitem_by_class_tuple(nxroot):
+def test_nxobject_getitem_by_class_list(nxroot):
     nxroot['entry'].create_class('log', NXlog)
     nxroot['entry'].create_class('events_0', NXevent_data)
     nxroot['entry'].create_class('events_1', NXevent_data)
     nxroot['entry']['field1'] = sc.arange('event', 4.0, unit='ns')
-    assert set(nxroot['entry'][(NXlog,
-                                NXevent_data)]) == {'log', 'events_0', 'events_1'}
-    assert set(nxroot['entry'][(NXlog, Field)]) == {'log', 'field1'}
+    assert set(nxroot['entry'][[NXlog,
+                                NXevent_data]]) == {'log', 'events_0', 'events_1'}
+    assert set(nxroot['entry'][[NXlog, Field]]) == {'log', 'field1'}
 
 
 def test_nxobject_dataset_items_are_returned_as_Field(nxroot):


### PR DESCRIPTION
A list is more consistent with other Python behavior. For example, in NumPy a tuple is used for multi-dim slicing, but a list can select multiple indices along a single dimension: `a[[2,5]]`.