### PR TITLE
Fix exception when iterating NXobject that cannot be loaded

### DIFF
--- a/src/scippnexus/nxobject.py
+++ b/src/scippnexus/nxobject.py
@@ -421,6 +421,9 @@ class NXobject:
     def _ipython_key_completions_(self) -> List[str]:
         return list(self.keys())
 
+    def __iter__(self):
+        yield from self._group
+
     def keys(self) -> List[str]:
         return self._group.keys()
 

--- a/tests/nexus_test.py
+++ b/tests/nexus_test.py
@@ -58,7 +58,8 @@ def test_nxobject_items(nxroot):
 
 def test_nxobject_iter(nxroot):
     nxroot.create_class('entry2', NXentry)
-    # With missing __iter__ this used to raise since NXroot cannot be loaded.
+    # With missing __iter__ this used to raise since Python just calls __getitem__
+    # with an int range.
     list(nxroot)
     for key in nxroot:
         pass

--- a/tests/nexus_test.py
+++ b/tests/nexus_test.py
@@ -56,6 +56,14 @@ def test_nxobject_items(nxroot):
             }
 
 
+def test_nxobject_iter(nxroot):
+    nxroot.create_class('entry2', NXentry)
+    # With missing __iter__ this used to raise since NXroot cannot be loaded.
+    list(nxroot)
+    for key in nxroot:
+        pass
+
+
 def test_nxobject_entry(nxroot):
     entry = nxroot['entry']
     assert entry.nx_class == NXentry


### PR DESCRIPTION
Without `__iter__` Python apparently just calls `__getitem__` with integers starting at 0 (until `IndexError`).