### PR TITLE
Copy more complete pre-commit config from scipp

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,19 +1,62 @@
 repos:
-- repo: https://github.com/pycqa/flake8
-  rev: 5.0.4
-  hooks:
-    - id: flake8
-      types: ["python"]
-- repo: https://github.com/pre-commit/mirrors-yapf
-  rev: v0.32.0
-  hooks:
-    - id: yapf
-      types: ["python"]
-      additional_dependencies: ["toml"]
-- repo: https://github.com/kynan/nbstripout
-  rev: 0.6.0
-  hooks:
-    - id: nbstripout
-      types: ["jupyter"]
-      args: ['--drop-empty-cells',
-             '--extra-keys', 'metadata.language_info.version cell.metadata.jp-MarkdownHeadingCollapsed']
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v4.3.0
+    hooks:
+      - id: check-added-large-files
+      - id: check-json
+        exclude: asv.conf.json
+      - id: check-toml
+      - id: check-yaml
+        exclude: conda/meta.yaml
+      - id: detect-private-key
+      - id: trailing-whitespace
+        args: [ --markdown-linebreak-ext=md ]
+        exclude: '\.svg'
+  - repo: https://github.com/pycqa/flake8
+    rev: 4.0.1
+    hooks:
+      - id: flake8
+        types: ["python"]
+        additional_dependencies: ["flake8-bugbear==22.10.27"]
+  - repo: https://github.com/pycqa/bandit
+    rev: 1.7.4
+    hooks:
+      - id: bandit
+        additional_dependencies: ["bandit[toml]"]
+        args: ["-c", "pyproject.toml"]
+  - repo: https://github.com/pycqa/isort
+    rev: 5.10.1
+    hooks:
+      - id: isort
+        name: isort (python)
+  - repo: https://github.com/pre-commit/mirrors-yapf
+    rev: v0.32.0
+    hooks:
+      - id: yapf
+        args: ["-i", "-r"]
+        types: ["python"]
+        additional_dependencies: ["toml"]
+  - repo: https://github.com/kynan/nbstripout
+    rev: 0.6.0
+    hooks:
+      - id: nbstripout
+        types: ["jupyter"]
+        args: ["--drop-empty-cells",
+               "--extra-keys 'metadata.language_info.version cell.metadata.jp-MarkdownHeadingCollapsed cell.metadata.pycharm'"]
+  - repo: https://github.com/codespell-project/codespell
+    rev: v2.2.2
+    hooks:
+      - id: codespell
+        additional_dependencies:
+          - tomli
+  - repo: https://github.com/pre-commit/pygrep-hooks
+    rev: v1.9.0
+    hooks:
+      - id: python-no-eval
+        exclude: "object_list.py"
+      - id: python-no-log-warn
+      - id: python-use-type-annotations
+      - id: rst-backticks
+      - id: rst-directive-colons
+      - id: rst-inline-touching-normal
+      - id: text-unicode-replacement-char

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,16 +1,16 @@
 # -*- coding: utf-8 -*-
 
 import doctest
-from datetime import date
-import scippnexus
-
 import os
 import sys
-
+from datetime import date
 from typing import Any, Dict, Optional
+
+import sphinx_book_theme
 from docutils.nodes import document
 from sphinx.application import Sphinx
-import sphinx_book_theme
+
+import scippnexus
 
 sys.path.insert(0, os.path.abspath('.'))
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -31,7 +31,7 @@ News
   This provides and experimental mechanism for customizing reading and writing of data based on NeXus application definitions.
 - [September 2022] scippnexus-0.3.0 has been released.
 - [August 2022] scippnexus-0.2.0 has been released.
-  This provides more convenient access to child groups based on the `NX_class` attribute.
+  This provides more convenient access to child groups based on the ``NX_class`` attribute.
 
 Get in touch
 ------------

--- a/docs/version.py
+++ b/docs/version.py
@@ -1,8 +1,9 @@
+import argparse
 import sys
 from typing import List
-from packaging.version import parse, Version, InvalidVersion
+
 import requests
-import argparse
+from packaging.version import InvalidVersion, Version, parse
 
 
 def _get_releases(repo: str, organization: str = 'scipp') -> List[Version]:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,6 +19,11 @@ filterwarnings = [
 # Excluding tests because bandit doesn't like `assert`.
 exclude_dirs = ["docs/conf.py", "tests"]
 
+[tool.isort]
+multi_line_output = 3
+line_length = 88
+include_trailing_comma = true
+
 [tool.mypy]
 mypy_path = "src"
 ignore_missing_imports = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,8 +20,9 @@ filterwarnings = [
 exclude_dirs = ["docs/conf.py", "tests"]
 
 [tool.isort]
-multi_line_output = 3
+skip_gitignore = true
 line_length = 88
+multi_line_output = 3
 include_trailing_comma = true
 
 [tool.mypy]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,6 +15,10 @@ filterwarnings = [
   "ignore::UserWarning",
 ]
 
+[tool.bandit]
+# Excluding tests because bandit doesn't like `assert`.
+exclude_dirs = ["docs/conf.py", "tests"]
+
 [tool.mypy]
 mypy_path = "src"
 ignore_missing_imports = true

--- a/src/scippnexus/__init__.py
+++ b/src/scippnexus/__init__.py
@@ -4,18 +4,17 @@
 
 # flake8: noqa
 import importlib.metadata
+
 try:
     __version__ = importlib.metadata.version(__package__ or __name__)
 except importlib.metadata.PackageNotFoundError:
     __version__ = "0.0.0"
 
 from . import typing
+from .definition import ApplicationDefinition
 from .file import File
-from .nxobject import NXobject, Field, Attrs
-from .nxobject import NexusStructureError
 from .nexus_classes import *
-
 from .nxdata import NXdataStrategy
 from .nxdetector import NXdetectorStrategy
 from .nxlog import NXlogStrategy
-from .definition import ApplicationDefinition
+from .nxobject import Attrs, Field, NexusStructureError, NXobject

--- a/src/scippnexus/_common.py
+++ b/src/scippnexus/_common.py
@@ -1,9 +1,11 @@
 # SPDX-License-Identifier: BSD-3-Clause
 # Copyright (c) 2023 Scipp contributors (https://github.com/scipp)
 # @author Simon Heybrock
-from typing import Dict, Union, List, Optional
-import scipp as sc
+from typing import Dict, List, Optional, Union
+
 import numpy as np
+import scipp as sc
+
 from .typing import ScippIndex
 
 

--- a/src/scippnexus/_hdf5_nexus.py
+++ b/src/scippnexus/_hdf5_nexus.py
@@ -2,8 +2,7 @@
 # Copyright (c) 2023 Scipp contributors (https://github.com/scipp)
 # @author Matthew Jones
 import warnings
-
-from typing import Union, Any
+from typing import Any, Union
 
 import h5py
 import numpy as np

--- a/src/scippnexus/definition.py
+++ b/src/scippnexus/definition.py
@@ -2,6 +2,7 @@
 # Copyright (c) 2023 Scipp contributors (https://github.com/scipp)
 # @author Simon Heybrock
 from abc import ABC, abstractmethod
+
 from .nxobject import NXobject
 
 

--- a/src/scippnexus/definitions/nxcansas.py
+++ b/src/scippnexus/definitions/nxcansas.py
@@ -1,10 +1,12 @@
 # SPDX-License-Identifier: BSD-3-Clause
 # Copyright (c) 2023 Scipp contributors (https://github.com/scipp)
 # @author Simon Heybrock
+from typing import Literal, Optional, Tuple, Union
+
 import scipp as sc
-from typing import Optional, Tuple, Union, Literal
-from ..nxobject import NXobject
+
 from ..definition import ApplicationDefinition as BaseDef
+from ..nxobject import NXobject
 
 
 class ApplicationDefinition(BaseDef):
@@ -17,7 +19,7 @@ class ApplicationDefinition(BaseDef):
     def make_strategy(self, group: NXobject):
         # This approach will likely need to be generalized as many application
         # definitions to not define a "class attribute" in the style of canSAS_class,
-        # but seem to rely on basic strcture and the NX_class attribute.
+        # but seem to rely on basic structure and the NX_class attribute.
         if (definition_class := group.attrs.get(self._class_attribute,
                                                 self._default_class)) is not None:
             return self._strategies.get(definition_class)

--- a/src/scippnexus/file.py
+++ b/src/scippnexus/file.py
@@ -2,6 +2,7 @@
 # Copyright (c) 2023 Scipp contributors (https://github.com/scipp)
 # @author Simon Heybrock
 from contextlib import AbstractContextManager
+
 import h5py
 
 from .nexus_classes import NXroot

--- a/src/scippnexus/leaf.py
+++ b/src/scippnexus/leaf.py
@@ -2,9 +2,11 @@
 # Copyright (c) 2023 Scipp contributors (https://github.com/scipp)
 # @author Simon Heybrock
 from typing import Dict, Union
+
 import scipp as sc
-from .nxobject import NXobject, ScippIndex
+
 from ._common import to_plain_index
+from .nxobject import NXobject, ScippIndex
 
 
 class Leaf(NXobject):

--- a/src/scippnexus/nexus_classes.py
+++ b/src/scippnexus/nexus_classes.py
@@ -4,8 +4,8 @@
 from .nxdata import NXdata  # noqa F401
 from .nxdetector import NXdetector  # noqa F401
 from .nxdisk_chopper import NXdisk_chopper  # noqa F401
-from .nxfermi_chopper import NXfermi_chopper  # noqa F401
 from .nxevent_data import NXevent_data  # noqa F401
+from .nxfermi_chopper import NXfermi_chopper  # noqa F401
 from .nxlog import NXlog  # noqa F401
 from .nxmonitor import NXmonitor  # noqa F401
 from .nxobject import NXobject, NXroot  # noqa F401

--- a/src/scippnexus/nxdata.py
+++ b/src/scippnexus/nxdata.py
@@ -2,13 +2,16 @@
 # Copyright (c) 2023 Scipp contributors (https://github.com/scipp)
 # @author Simon Heybrock
 from __future__ import annotations
-from typing import List, Union, Optional
+
+from typing import List, Optional, Union
 from warnings import warn
-import scipp as sc
+
 import numpy as np
+import scipp as sc
+
 from ._common import to_child_select
+from .nxobject import Field, NexusStructureError, NXobject, ScippIndex, asarray
 from .typing import H5Group
-from .nxobject import Field, NXobject, ScippIndex, NexusStructureError, asarray
 
 
 class NXdataStrategy:

--- a/src/scippnexus/nxdetector.py
+++ b/src/scippnexus/nxdetector.py
@@ -10,8 +10,14 @@ import scipp as sc
 
 from .nxdata import NXdata, NXdataStrategy
 from .nxevent_data import NXevent_data
-from .nxobject import (Field, NexusStructureError, NXobject, ScippIndex, asarray,
-                       is_dataset)
+from .nxobject import (
+    Field,
+    NexusStructureError,
+    NXobject,
+    ScippIndex,
+    asarray,
+    is_dataset,
+)
 
 
 class NXdetectorStrategy(NXdataStrategy):

--- a/src/scippnexus/nxdetector.py
+++ b/src/scippnexus/nxdetector.py
@@ -2,13 +2,16 @@
 # Copyright (c) 2023 Scipp contributors (https://github.com/scipp)
 # @author Simon Heybrock
 from __future__ import annotations
+
 from copy import copy
 from typing import List, Optional, Union
+
 import scipp as sc
-from .nxobject import NXobject, Field, ScippIndex, NexusStructureError
-from .nxobject import is_dataset, asarray
+
 from .nxdata import NXdata, NXdataStrategy
 from .nxevent_data import NXevent_data
+from .nxobject import (Field, NexusStructureError, NXobject, ScippIndex, asarray,
+                       is_dataset)
 
 
 class NXdetectorStrategy(NXdataStrategy):

--- a/src/scippnexus/nxevent_data.py
+++ b/src/scippnexus/nxevent_data.py
@@ -2,11 +2,12 @@
 # Copyright (c) 2023 Scipp contributors (https://github.com/scipp)
 # @author Simon Heybrock
 from typing import List, Union
+
 import numpy as np
 import scipp as sc
 
 from ._common import to_plain_index
-from .nxobject import NXobject, ScippIndex, NexusStructureError
+from .nxobject import NexusStructureError, NXobject, ScippIndex
 
 _event_dimension = "event"
 _pulse_dimension = "pulse"
@@ -62,7 +63,7 @@ class NXevent_data(NXobject):
 
         num_event = self["event_time_offset"].shape[0]
         # Some files contain uint64 "max" indices, which turn into negatives during
-        # conversion to int64. This is a hack to get arround this.
+        # conversion to int64. This is a hack to get around this.
         event_index[event_index < 0] = num_event
 
         if len(event_index) > 0:

--- a/src/scippnexus/nxlog.py
+++ b/src/scippnexus/nxlog.py
@@ -3,9 +3,11 @@
 # @author Simon Heybrock
 
 from typing import List, Union
+
 import scipp as sc
-from .nxobject import NXobject, ScippIndex
+
 from .nxdata import NXdata, NXdataStrategy
+from .nxobject import NXobject, ScippIndex
 
 
 class NXlogStrategy(NXdataStrategy):
@@ -20,7 +22,7 @@ class NXlogStrategy(NXdataStrategy):
         ndim = child_dataset.ndim
         shape = child_dataset.shape
         # The outermost axis in NXlog is pre-defined to 'time' (if present). Note
-        # that this may be overriden by an `axes` attribute, if defined for the group.
+        # that this may be overridden by an `axes` attribute, if defined for the group.
         if 'time' in group:
             raw_axes = ['time'] + (['.'] * (ndim - 1))
         else:

--- a/src/scippnexus/nxmonitor.py
+++ b/src/scippnexus/nxmonitor.py
@@ -2,8 +2,9 @@
 # Copyright (c) 2023 Scipp contributors (https://github.com/scipp)
 # @author Simon Heybrock
 from typing import Dict, Union
-from .nxobject import Field
+
 from .nxdetector import NXdetector
+from .nxobject import Field
 
 
 class NXmonitor(NXdetector):

--- a/src/scippnexus/nxobject.py
+++ b/src/scippnexus/nxobject.py
@@ -2,22 +2,24 @@
 # Copyright (c) 2023 Scipp contributors (https://github.com/scipp)
 # @author Simon Heybrock
 from __future__ import annotations
-import re
-import inspect
-import warnings
+
 import datetime
-import dateutil.parser
 import functools
-from typing import overload, List, Union, Any, Dict, Tuple, Protocol, Optional, Callable
+import inspect
+import re
+import warnings
+from typing import (Any, Callable, Dict, List, Optional, Protocol, Tuple, Union,
+                    overload)
+
+import dateutil.parser
+import h5py
 import numpy as np
 import scipp as sc
-import h5py
 
-from ._hdf5_nexus import _cset_to_encoding, _ensure_str
-from ._hdf5_nexus import _ensure_supported_int_type, _warn_latin1_decode
-from .typing import H5Group, H5Dataset, ScippIndex
-from ._common import to_plain_index
-from ._common import convert_time_to_datetime64
+from ._common import convert_time_to_datetime64, to_plain_index
+from ._hdf5_nexus import (_cset_to_encoding, _ensure_str, _ensure_supported_int_type,
+                          _warn_latin1_decode)
+from .typing import H5Dataset, H5Group, ScippIndex
 
 NXobjectIndex = Union[str, ScippIndex]
 
@@ -139,7 +141,7 @@ class Field:
     """
 
     def __init__(self, dataset: H5Dataset, *, ancestor, dims=None, is_time=None):
-        self._ancestor = ancestor  # Ususally the parent, but may be grandparent, etc.
+        self._ancestor = ancestor  # Usually the parent, but may be grandparent, etc.
         self._dataset = dataset
         self._shape = self._dataset.shape
         self._is_time = is_time
@@ -546,7 +548,7 @@ class NXobject:
         nxclasses = []
         # Avoiding self.values() since it is more costly, but mainly since there may be
         # edge cases where creation of Field/NXobject may raise on unrelated children.
-        for name, val in self._group.items():
+        for _, val in self._group.items():
             if not is_dataset(val):
                 nxclasses.append(self._make(val).nx_class)
         for key in set(nxclasses):

--- a/src/scippnexus/nxobject.py
+++ b/src/scippnexus/nxobject.py
@@ -8,8 +8,7 @@ import functools
 import inspect
 import re
 import warnings
-from typing import (Any, Callable, Dict, List, Optional, Protocol, Tuple, Union,
-                    overload)
+from typing import Any, Callable, Dict, List, Optional, Protocol, Tuple, Union, overload
 
 import dateutil.parser
 import h5py
@@ -17,8 +16,12 @@ import numpy as np
 import scipp as sc
 
 from ._common import convert_time_to_datetime64, to_plain_index
-from ._hdf5_nexus import (_cset_to_encoding, _ensure_str, _ensure_supported_int_type,
-                          _warn_latin1_decode)
+from ._hdf5_nexus import (
+    _cset_to_encoding,
+    _ensure_str,
+    _ensure_supported_int_type,
+    _warn_latin1_decode,
+)
 from .typing import H5Dataset, H5Group, ScippIndex
 
 NXobjectIndex = Union[str, ScippIndex]

--- a/src/scippnexus/nxsample.py
+++ b/src/scippnexus/nxsample.py
@@ -1,10 +1,12 @@
 # SPDX-License-Identifier: BSD-3-Clause
 # Copyright (c) 2023 Scipp contributors (https://github.com/scipp)
 # @author Simon Heybrock
-from .leaf import Leaf
 from typing import Dict, Union
+
 import scipp as sc
 from scipp.spatial import linear_transform
+
+from .leaf import Leaf
 from .nxobject import ScippIndex
 
 _matrix_units = dict(zip(['orientation_matrix', 'ub_matrix'], ['one', '1/Angstrom']))

--- a/src/scippnexus/nxtransformations.py
+++ b/src/scippnexus/nxtransformations.py
@@ -1,14 +1,17 @@
 # SPDX-License-Identifier: BSD-3-Clause
 # Copyright (c) 2023 Scipp contributors (https://github.com/scipp)
 # @author Simon Heybrock
-import numpy as np
 from typing import Union
+
+import numpy as np
 import scipp as sc
 import scipp.spatial
+
 try:
     from scipp.scipy import interpolate
 except ImportError:  # scipp<22.11
     from scipp import interpolate
+
 from .nxobject import Field, NXobject, ScippIndex
 
 

--- a/src/scippnexus/typing.py
+++ b/src/scippnexus/typing.py
@@ -3,7 +3,7 @@
 # @author Simon Heybrock
 from __future__ import annotations
 
-from typing import (TYPE_CHECKING, Any, Callable, Dict, List, Protocol, Tuple, Union)
+from typing import TYPE_CHECKING, Any, Callable, Dict, List, Protocol, Tuple, Union
 
 
 class H5Base(Protocol):

--- a/src/scippnexus/typing.py
+++ b/src/scippnexus/typing.py
@@ -2,8 +2,8 @@
 # Copyright (c) 2023 Scipp contributors (https://github.com/scipp)
 # @author Simon Heybrock
 from __future__ import annotations
-from typing import Any, Protocol, Union, Tuple, Dict, List, Callable
-from typing import TYPE_CHECKING
+
+from typing import (TYPE_CHECKING, Any, Callable, Dict, List, Protocol, Tuple, Union)
 
 
 class H5Base(Protocol):

--- a/tests/application_definition_test.py
+++ b/tests/application_definition_test.py
@@ -1,8 +1,9 @@
 import h5py
-import scipp as sc
-from scippnexus import NXroot, NXentry
-from scippnexus.definitions.nxcansas import NXcanSAS, SASentry, SASdata
 import pytest
+import scipp as sc
+
+from scippnexus import NXentry, NXroot
+from scippnexus.definitions.nxcansas import NXcanSAS, SASdata, SASentry
 
 
 @pytest.fixture()

--- a/tests/nexus_test.py
+++ b/tests/nexus_test.py
@@ -6,8 +6,16 @@ import numpy as np
 import pytest
 import scipp as sc
 
-from scippnexus import (Field, NexusStructureError, NXdetector, NXentry, NXevent_data,
-                        NXlog, NXmonitor, NXroot)
+from scippnexus import (
+    Field,
+    NexusStructureError,
+    NXdetector,
+    NXentry,
+    NXevent_data,
+    NXlog,
+    NXmonitor,
+    NXroot,
+)
 
 # representative sample of UTF-8 test strings from
 # https://www.w3.org/2001/06/utf-8-test/UTF-8-demo.html

--- a/tests/nexus_test.py
+++ b/tests/nexus_test.py
@@ -5,9 +5,9 @@ import h5py
 import numpy as np
 import pytest
 import scipp as sc
-from scippnexus import (Field, NXroot, NXentry, NXmonitor, NXlog, NXevent_data,
-                        NXdetector)
-from scippnexus import NexusStructureError
+
+from scippnexus import (Field, NexusStructureError, NXdetector, NXentry, NXevent_data,
+                        NXlog, NXmonitor, NXroot)
 
 # representative sample of UTF-8 test strings from
 # https://www.w3.org/2001/06/utf-8-test/UTF-8-demo.html
@@ -61,7 +61,7 @@ def test_nxobject_iter(nxroot):
     # With missing __iter__ this used to raise since Python just calls __getitem__
     # with an int range.
     list(nxroot)
-    for key in nxroot:
+    for _ in nxroot:
         pass
 
 

--- a/tests/nxdata_test.py
+++ b/tests/nxdata_test.py
@@ -1,8 +1,9 @@
 import h5py
 import numpy as np
-import scipp as sc
-from scippnexus import Field, NXroot, NXentry, NXdata, NXlog
 import pytest
+import scipp as sc
+
+from scippnexus import Field, NXdata, NXentry, NXlog, NXroot
 
 
 @pytest.fixture()

--- a/tests/nxdetector_test.py
+++ b/tests/nxdetector_test.py
@@ -1,8 +1,9 @@
 import h5py
 import numpy as np
-import scipp as sc
-from scippnexus import NXroot, NXentry, NXdetector, NXevent_data, NexusStructureError
 import pytest
+import scipp as sc
+
+from scippnexus import (NexusStructureError, NXdetector, NXentry, NXevent_data, NXroot)
 
 
 @pytest.fixture()

--- a/tests/nxdetector_test.py
+++ b/tests/nxdetector_test.py
@@ -3,7 +3,7 @@ import numpy as np
 import pytest
 import scipp as sc
 
-from scippnexus import (NexusStructureError, NXdetector, NXentry, NXevent_data, NXroot)
+from scippnexus import NexusStructureError, NXdetector, NXentry, NXevent_data, NXroot
 
 
 @pytest.fixture()

--- a/tests/nxmonitor_test.py
+++ b/tests/nxmonitor_test.py
@@ -1,7 +1,8 @@
 import h5py
-import scipp as sc
-from scippnexus import NXroot, NXentry, NXmonitor, NXevent_data
 import pytest
+import scipp as sc
+
+from scippnexus import NXentry, NXevent_data, NXmonitor, NXroot
 
 
 @pytest.fixture()

--- a/tests/nxtransformations_test.py
+++ b/tests/nxtransformations_test.py
@@ -3,8 +3,14 @@ import numpy as np
 import pytest
 import scipp as sc
 
-from scippnexus import (NXdetector, NXentry, NXlog, NXroot, NXtransformations,
-                        nxtransformations)
+from scippnexus import (
+    NXdetector,
+    NXentry,
+    NXlog,
+    NXroot,
+    NXtransformations,
+    nxtransformations,
+)
 
 
 @pytest.fixture()

--- a/tests/nxtransformations_test.py
+++ b/tests/nxtransformations_test.py
@@ -1,9 +1,10 @@
 import h5py
 import numpy as np
-import scipp as sc
-from scippnexus import NXroot, NXentry, NXdetector, NXtransformations, NXlog
-from scippnexus import nxtransformations
 import pytest
+import scipp as sc
+
+from scippnexus import (NXdetector, NXentry, NXlog, NXroot, NXtransformations,
+                        nxtransformations)
 
 
 @pytest.fixture()


### PR DESCRIPTION
Only change is removed clang-format, and applied formatting.

Right now there is an issue from isort and yapf undoing each others changes. Move to black?