### PR TITLE
Ignore cue_* fields in choppers which interfere with loading

### DIFF
--- a/src/scippnexus/nxlog.py
+++ b/src/scippnexus/nxlog.py
@@ -58,7 +58,9 @@ class NXlog(NXobject):
 
     @property
     def _nxbase(self) -> NXdata:
-        return NXdata(self._group, strategy=NXlogStrategy)
+        return NXdata(self._group,
+                      strategy=NXlogStrategy,
+                      skip=['cue_timestamp_zero', 'cue_index'])
 
     def _getitem(self, select: ScippIndex) -> sc.DataArray:
         base = self._nxbase


### PR DESCRIPTION
Similar to the same mechanism we use for detector data.