### PR TITLE
Handle issues with getting field dims more gracefully

### DIFF
--- a/src/scippnexus/nxobject.py
+++ b/src/scippnexus/nxobject.py
@@ -362,7 +362,10 @@ class NXobject:
         if isinstance(name, str):
             item = self._group[name]
             if is_dataset(item):
-                dims = self._get_field_dims(name) if use_field_dims else None
+                try:
+                    dims = self._get_field_dims(name) if use_field_dims else None
+                except Exception:
+                    dims = None
                 return Field(item,
                              dims=dims,
                              ancestor=self,
@@ -377,9 +380,10 @@ class NXobject:
             if type(self)._getitem == NXobject._getitem:
                 raise
             else:
-                warnings.warn(
-                    f"Failed to load {self.name} as {type(self).__name__}:\n{e}\n"
+                msg = (
+                    f"Failed to load {self.name} as {type(self).__name__}: {e}. "
                     "Falling back to loading HDF5 group children as scipp.DataGroup.")
+                warnings.warn(msg)
             da = NXobject._getitem(self, name)
         if (t := self.depends_on) is not None:
 

--- a/src/scippnexus/nxobject.py
+++ b/src/scippnexus/nxobject.py
@@ -364,7 +364,10 @@ class NXobject:
             if is_dataset(item):
                 try:
                     dims = self._get_field_dims(name) if use_field_dims else None
-                except Exception:
+                except Exception as e:
+                    msg = (f"Failed to determine axis names of {item.name}: {e}. "
+                           "Falling back to default dimension labels.")
+                    warnings.warn(msg)
                     dims = None
                 return Field(item,
                              dims=dims,


### PR DESCRIPTION
Getting field dims leads to reading info from the group. If this is incomplete this may raise, with similar or different problems than that of loading the entire group.

If loading the group fails, the latest scippnexus is falling back to loading as a `DataGroup`. Similarly, this change avoids problems when trying to load fields of a broken/incomplete group.

Also includes a minor change with fewer linebreaks in warnings to improve readability. We should probably consider logging warnings instead?