### PR TITLE
Improve shape loading

### DIFF
--- a/docs/about/release-notes.rst
+++ b/docs/about/release-notes.rst
@@ -35,6 +35,7 @@ Features
 ~~~~~~~~
 
 * Improve handling of files with legacy ``signal`` and ``axis`` attributes, yielding better dim labels `#108 <https://github.com/scipp/scippnexus/pull/108>`_.
+* Improve loading and parsing of ``NXoff_geometry`` and ``NXcylindrical_geometry`` `#109 <https://github.com/scipp/scippnexus/pull/109>`_.
 
 Breaking changes
 ~~~~~~~~~~~~~~~~

--- a/src/scippnexus/nxcylindrical_geometry.py
+++ b/src/scippnexus/nxcylindrical_geometry.py
@@ -30,13 +30,16 @@ def _parse(*,
             "NXcylindrical_geometry contains mapping to `detector_number`.")
     # detector_number gives indices into cylinders, the naming in the NeXus
     # standard appears to be misleading
-    if parent_detector_number.size != detector_number.size:
+    if parent_detector_number.values.size != detector_number.values.size:
         raise NexusStructureError(
             "Number of detector numbers in NXcylindrical_geometry "
             "does not match the one given by the parent.")
     detecting_cylinders = ds['cylinder', detector_number.values]
     # One cylinder per detector
-    begin = sc.arange('dummy', parent_detector_number.size, unit=None, dtype='int64')
+    begin = sc.arange('dummy',
+                      parent_detector_number.values.size,
+                      unit=None,
+                      dtype='int64')
     end = begin + sc.index(1)
     shape = sc.bins(begin=begin, end=end, dim='cylinder', data=detecting_cylinders)
     return shape.fold(dim='dummy', sizes=parent_detector_number.sizes)

--- a/src/scippnexus/nxcylindrical_geometry.py
+++ b/src/scippnexus/nxcylindrical_geometry.py
@@ -39,7 +39,7 @@ def _parse(*,
 class NXcylindrical_geometry(NXobject):
     _dims = {
         'vertices': ('vertex', ),
-        'detector_number': ('cylinder_index', ),
+        'detector_number': ('detector_number', ),
         'cylinders': ('cylinder', 'vertex_index')
     }
 

--- a/src/scippnexus/nxcylindrical_geometry.py
+++ b/src/scippnexus/nxcylindrical_geometry.py
@@ -51,5 +51,6 @@ class NXcylindrical_geometry(NXobject):
             return sc.DType.vector3
         return None
 
-    def as_array(self, detector_number: Optional[sc.Variable] = None) -> sc.Variable:
+    def load_as_array(self,
+                      detector_number: Optional[sc.Variable] = None) -> sc.Variable:
         return _parse(**self[()], parent_detector_number=detector_number)

--- a/src/scippnexus/nxcylindrical_geometry.py
+++ b/src/scippnexus/nxcylindrical_geometry.py
@@ -1,17 +1,45 @@
 # SPDX-License-Identifier: BSD-3-Clause
 # Copyright (c) 2023 Scipp contributors (https://github.com/scipp)
 # @author Simon Heybrock
-from typing import Tuple, Union
+from typing import Optional, Tuple, Union
 
 import scipp as sc
 
-from .leaf import Leaf
+from .nxobject import NexusStructureError, NXobject
 
 
-class NXcylindrical_geometry(Leaf):
+def _parse(*,
+           vertices: sc.Variable,
+           cylinders: sc.Variable,
+           detector_number: Optional[sc.Variable] = None,
+           parent_detector_number: Optional[sc.Variable] = None) -> sc.Variable:
+    cv = vertices[cylinders.values.ravel()]
+    cv = cv.fold(dim=vertices.dim, sizes=cylinders.sizes)
+    cv = cv.rename({cylinders.dims[-1]: vertices.dim})
+    if detector_number is None:
+        # All cylinders belong to the same shape
+        return sc.bins(begin=sc.index(0), dim='cylinder', data=cv)
+    if parent_detector_number is None:
+        raise NexusStructureError(
+            "`detector_number` not given, but "
+            "NXcylindrical_geometry contains mapping to `detector_number`.")
+    # detector_number gives indices into cylinders, the naming in the NeXus
+    # standard appears to be misleading
+    if parent_detector_number.size != detector_number.size:
+        raise NexusStructureError(
+            "Number of detector numbers in NXcylindrical_geometry "
+            "does not match the one given by the parent.")
+    detecting_cylinders = cv['cylinder', detector_number.values]
+    # One cylinder per detector
+    begin = sc.arange('dummy', parent_detector_number.size, unit=None, dtype='int64')
+    end = begin + sc.index(1)
+    return sc.bins(begin=begin, end=end, dim='cylinder', data=detecting_cylinders)
+
+
+class NXcylindrical_geometry(NXobject):
     _dims = {
         'vertices': ('vertex', ),
-        'detector_number': ('detector_number', ),
+        'detector_number': ('cylinder_index', ),
         'cylinders': ('cylinder', 'vertex_index')
     }
 
@@ -22,3 +50,6 @@ class NXcylindrical_geometry(Leaf):
         if name == 'vertices':
             return sc.DType.vector3
         return None
+
+    def as_array(self, detector_number: Optional[sc.Variable] = None) -> sc.Variable:
+        return _parse(**self[()], parent_detector_number=detector_number)

--- a/src/scippnexus/nxdata.py
+++ b/src/scippnexus/nxdata.py
@@ -10,7 +10,9 @@ import numpy as np
 import scipp as sc
 
 from ._common import to_child_select
+from .nxcylindrical_geometry import NXcylindrical_geometry
 from .nxobject import Field, NexusStructureError, NXobject, ScippIndex, asarray
+from .nxoff_geometry import NXoff_geometry
 from .nxtransformations import NXtransformations
 from .typing import H5Group
 
@@ -246,7 +248,8 @@ class NXdata(NXobject):
             # It is not entirely clear whether skipping NXtransformations is the right
             # solution. In principle NXobject will load them via the 'depends_on'
             # mechanism, so for valid files this should be sufficient.
-            if not isinstance(self._get_child(name), (Field, NXtransformations)):
+            allowed = (Field, NXtransformations, NXcylindrical_geometry, NXoff_geometry)
+            if not isinstance(self._get_child(name), allowed):
                 raise NexusStructureError(
                     "Invalid NXdata: may not contain nested groups")
 

--- a/src/scippnexus/nxdetector.py
+++ b/src/scippnexus/nxdetector.py
@@ -168,6 +168,13 @@ class NXdetector(NXobject):
         return self._signal.unit
 
     @property
+    def detector_number(self) -> Optional[Field]:
+        for key in self._detector_number_fields:
+            if key in self:
+                return key
+        return None
+
+    @property
     def _event_grouping(self) -> Union[None, Dict[str, Any]]:
         for key in self._detector_number_fields:
             if key in self:

--- a/src/scippnexus/nxobject.py
+++ b/src/scippnexus/nxobject.py
@@ -419,9 +419,13 @@ class NXobject:
             # loaded.
             if isinstance(t, str):
                 from .nexus_classes import NXtransformations
-                for name, group in self[NXtransformations].items():
-                    insert(name, group[()])
-
+                for key, group in self[NXtransformations].items():
+                    insert(key, group[()])
+        from .nxoff_geometry import NXoff_geometry, off_to_shape
+        for key, off in self[NXoff_geometry].items():
+            detector_number = getattr(self, 'detector_number', None)
+            detector_number = da.coords[detector_number]
+            da.coords[key] = off_to_shape(**off[()], detector_number=detector_number)
         return da
 
     def _get_children_by_nx_class(

--- a/src/scippnexus/nxobject.py
+++ b/src/scippnexus/nxobject.py
@@ -444,7 +444,7 @@ class NXobject:
         ...
 
     @overload
-    def __getitem__(self, name: Union[type, Tuple[type]]) -> Dict[str, 'NXobject']:
+    def __getitem__(self, name: Union[type, List[type]]) -> Dict[str, 'NXobject']:
         ...
 
     def __getitem__(self, name):

--- a/src/scippnexus/nxobject.py
+++ b/src/scippnexus/nxobject.py
@@ -402,10 +402,10 @@ class NXobject:
             from .nxcylindrical_geometry import NXcylindrical_geometry
             from .nxoff_geometry import NXoff_geometry
             da = self._getitem(name)
+            detector_number = getattr(self, 'detector_number', None)
+            if detector_number is not None:
+                detector_number = da.coords[detector_number]
             for key, child in self[[NXcylindrical_geometry, NXoff_geometry]].items():
-                detector_number = getattr(self, 'detector_number', None)
-                if detector_number is not None:
-                    detector_number = da.coords[detector_number]
                 insert(da, key, child.load_as_array(detector_number=detector_number))
         except Exception as e:
             # If the child class cannot load this group, we fall back to returning the

--- a/src/scippnexus/nxoff_geometry.py
+++ b/src/scippnexus/nxoff_geometry.py
@@ -1,19 +1,63 @@
 # SPDX-License-Identifier: BSD-3-Clause
 # Copyright (c) 2023 Scipp contributors (https://github.com/scipp)
 # @author Simon Heybrock
-from typing import Tuple, Union
+from typing import Optional, Tuple, Union
 
 import scipp as sc
 
-from .leaf import Leaf
+from .nxobject import NXobject, ScippIndex
 
 
-class NXoff_geometry(Leaf):
+def off_to_shape(*,
+                 vertices: sc.Variable,
+                 winding_order: sc.Variable,
+                 faces: sc.Variable,
+                 detector_faces: Optional[sc.Variable] = None) -> sc.Variable:
+    # TODO shape and dims should be:
+    # [face] if no detector_faces.. or []? The latter! Wrap in scalar binned
+    # [detector_number] otherwise (but must get name from parent?)
+    # TODO select
+    vw = vertices[winding_order.values]
+    fvw = sc.bins(begin=faces, data=vw, dim=vw.dim)
+    low = fvw.bins.size().min().value
+    high = fvw.bins.size().max().value
+    if low == high:
+        fvw = vw.fold(dim=vertices.dim, sizes={faces.dim: -1, vertices.dim: low})
+    else:
+        raise NotImplementedError("Conversion from OFF to shape not implemented for "
+                                  "inconsistent number of vertices in faces.")
+    if detector_faces is None:
+        return sc.bins(begin=sc.index(0), dim=faces.dim, data=fvw)
+    else:
+        shape_index = detector_faces['dummy', 0].copy()
+        detid = detector_faces['dummy', 1].copy()
+        da = sc.DataArray(shape_index, coords={
+            'detector_number': detid
+        }).group('detector_number')
+        comps = da.bins.constituents
+        comps['data'] = fvw[faces.dim, comps['data'].values]
+        return sc.DataArray(sc.bins(**comps), coords=da.coords)
+
+
+class NXoff_geometry(NXobject):
     _dims = {
+        'detector_faces': ('face', 'dummy'),
         'vertices': ('vertex', ),
         'winding_order': ('winding_order', ),
         'faces': ('face', )
     }
+
+    @property
+    def dims(self) -> Tuple[str]:
+        if 'detector_faces' in self:
+            return 'TODO'
+        return ()
+
+    @property
+    def shape(self) -> Tuple[int]:
+        if 'detector_faces' in self:
+            return 'TODO'
+        return ()
 
     def _get_field_dims(self, name: str) -> Union[None, Tuple[str]]:
         return self._dims.get(name)

--- a/src/scippnexus/nxoff_geometry.py
+++ b/src/scippnexus/nxoff_geometry.py
@@ -17,10 +17,6 @@ def off_to_shape(*,
     """
     Convert OFF shape description to simpler shape representation.
     """
-    # TODO shape and dims should be:
-    # [face] if no detector_faces.. or []? The latter! Wrap in scalar binned
-    # [detector_number] otherwise (but must get name from parent?)
-    # TODO select
     vw = vertices[winding_order.values]
     fvw = sc.bins(begin=faces, data=vw, dim=vw.dim)
     low = fvw.bins.size().min().value
@@ -30,8 +26,6 @@ def off_to_shape(*,
     else:
         raise NotImplementedError("Conversion from OFF to shape not implemented for "
                                   "inconsistent number of vertices in faces.")
-    # TODO check that both or neither are None?
-    # TODO no! may be single shape for all detectors! return scalar binned
     if detector_faces is None:  # if detector_number is not None, all have same shape
         return sc.bins(begin=sc.index(0), dim=faces.dim, data=fvw)
     if detector_number is None:
@@ -62,3 +56,7 @@ class NXoff_geometry(NXobject):
         if name == 'vertices':
             return sc.DType.vector3
         return None
+
+    def load_as_array(self,
+                      detector_number: Optional[sc.Variable] = None) -> sc.Variable:
+        return off_to_shape(**self[()], detector_number=detector_number)

--- a/tests/nxdetector_test.py
+++ b/tests/nxdetector_test.py
@@ -454,7 +454,6 @@ def test_cylindrical_geometry_with_detector_numbers(nxroot):
     loaded = detector[...]
     shape = loaded.coords['shape']
     assert shape.dims == detector_number.dims
-    print(shape.bins.size())
     for i in [0, 3]:
         assert sc.identical(
             shape.values[i],

--- a/tests/nxdetector_test.py
+++ b/tests/nxdetector_test.py
@@ -8,6 +8,7 @@ from scippnexus import (
     NXdetector,
     NXentry,
     NXevent_data,
+    NXobject,
     NXoff_geometry,
     NXroot,
 )
@@ -313,7 +314,9 @@ def test_nxevent_data_selection_yields_correct_pulses(nxroot):
     assert np.array_equal(Load()['pulse', :-2], [3, 0])
 
 
-def create_off_geometry_detector_numbers_1234(group, name):
+def create_off_geometry_detector_numbers_1234(group: NXobject,
+                                              name: str,
+                                              detector_faces: bool = True):
     off = group.create_class(name, NXoff_geometry)
     # square with point in center
     values = np.array([[0, 0, 0], [0, 1, 0], [1, 0, 0], [1, 1, 0], [0.5, 0.5, 0]])
@@ -323,18 +326,21 @@ def create_off_geometry_detector_numbers_1234(group, name):
                                     values=[0, 1, 4, 1, 2, 4, 2, 3, 4, 3, 0, 4],
                                     unit=None)
     off['faces'] = sc.array(dims=['_'], values=[0, 3, 6, 9], unit=None)
-    off['detector_faces'] = sc.array(dims=['_', 'dummy'],
-                                     values=[[0, 1], [1, 2], [2, 3], [3, 4]],
-                                     unit=None)
+    if detector_faces:
+        off['detector_faces'] = sc.array(dims=['_', 'dummy'],
+                                         values=[[0, 1], [1, 2], [2, 3], [3, 4]],
+                                         unit=None)
 
 
-def test_loads_data_with_coords_and_off_geometry(nxroot):
+@pytest.mark.parametrize('detid_name',
+                         ['detector_number', 'pixel_id', 'spectrum_index'])
+def test_loads_data_with_coords_and_off_geometry(nxroot, detid_name):
     da = sc.DataArray(
         sc.array(dims=['xx', 'yy'], unit='K', values=[[1.1, 2.2], [3.3, 4.4]]))
     da.coords['detector_number'] = detector_numbers_xx_yy_1234()
     da.coords['xx'] = sc.array(dims=['xx'], unit='m', values=[0.1, 0.2])
     detector = nxroot.create_class('detector0', NXdetector)
-    detector.create_field('detector_number', da.coords['detector_number'])
+    detector.create_field(detid_name, da.coords['detector_number'])
     detector.create_field('xx', da.coords['xx'])
     detector.create_field('data', da.data)
     detector.attrs['axes'] = ['xx', 'yy']
@@ -342,3 +348,25 @@ def test_loads_data_with_coords_and_off_geometry(nxroot):
     loaded = detector[...]
     assert sc.identical(loaded.coords['shape'].bins.size(),
                         sc.array(dims=da.dims, values=[[1, 1], [1, 1]], unit=None))
+
+
+def test_missing_detector_numbers_triggers_fallback_given_off_geometry_with_det_faces(
+        nxroot):
+    var = sc.array(dims=['xx', 'yy'], unit='K', values=[[1.1, 2.2], [3.3, 4.4]])
+    detector = nxroot.create_class('detector0', NXdetector)
+    detector.create_field('data', var)
+    detector.attrs['axes'] = ['xx', 'yy']
+    create_off_geometry_detector_numbers_1234(detector, name='shape')
+    assert isinstance(detector[...], sc.DataGroup)
+
+
+def test_off_geometry_with_detector_faces_loaded_as_0d_with_multiple_faces(nxroot):
+    var = sc.array(dims=['xx', 'yy'], unit='K', values=[[1.1, 2.2], [3.3, 4.4]])
+    detector = nxroot.create_class('detector0', NXdetector)
+    detector.create_field('data', var)
+    detector.attrs['axes'] = ['xx', 'yy']
+    create_off_geometry_detector_numbers_1234(detector,
+                                              name='shape',
+                                              detector_faces=False)
+    assert detector[...].coords['shape'].dims == ()
+    assert sc.identical(detector[...].coords['shape'].bins.size(), sc.index(4))

--- a/tests/nxdetector_test.py
+++ b/tests/nxdetector_test.py
@@ -361,7 +361,9 @@ def test_missing_detector_numbers_triggers_fallback_given_off_geometry_with_det_
     detector.create_field('data', var)
     detector.attrs['axes'] = ['xx', 'yy']
     create_off_geometry_detector_numbers_1234(detector, name='shape')
-    assert isinstance(detector[...], sc.DataGroup)
+    loaded = detector[...]
+    assert isinstance(loaded, sc.DataGroup)
+    assert sc.identical(loaded['shape'], detector['shape'][()])
 
 
 def test_off_geometry_without_detector_faces_loaded_as_0d_with_multiple_faces(nxroot):

--- a/tests/nxdetector_test.py
+++ b/tests/nxdetector_test.py
@@ -347,8 +347,11 @@ def test_loads_data_with_coords_and_off_geometry(nxroot, detid_name):
     detector.attrs['axes'] = ['xx', 'yy']
     create_off_geometry_detector_numbers_1234(detector, name='shape')
     loaded = detector[...]
+    expected = snx.nxoff_geometry.off_to_shape(
+        **detector['shape'][()], detector_number=da.coords['detector_number'])
     assert sc.identical(loaded.coords['shape'].bins.size(),
                         sc.array(dims=da.dims, values=[[1, 1], [1, 1]], unit=None))
+    assert sc.identical(loaded.coords['shape'], expected)
 
 
 def test_missing_detector_numbers_triggers_fallback_given_off_geometry_with_det_faces(

--- a/tests/nxoff_geometry_test.py
+++ b/tests/nxoff_geometry_test.py
@@ -3,7 +3,7 @@ import numpy as np
 import pytest
 import scipp as sc
 
-from scippnexus import NXentry, NXoff_geometry, NXroot
+from scippnexus import NexusStructureError, NXentry, NXoff_geometry, NXroot
 from scippnexus.nxoff_geometry import off_to_shape
 
 
@@ -51,6 +51,22 @@ def test_off_to_shape_without_detector_faces_yields_scalar_shape_with_all_faces(
     assert sc.identical(shape.bins.size(), sc.index(2))
 
 
+def test_off_to_shape_raises_if_detector_faces_but_not_detector_numbers_given(nxroot):
+    off = nxroot['entry'].create_class('off', NXoff_geometry)
+    values = np.array([[1, 2, 3], [4, 5, 6], [7, 8, 9]])
+    off['vertices'] = sc.array(dims=['_', 'comp'], values=values, unit='m')
+    off['winding_order'] = sc.array(dims=['_'], values=[0, 1, 2, 0, 2, 1], unit=None)
+    off['faces'] = sc.array(dims=['_'], values=[0, 3], unit=None)
+    det_num1 = 1
+    det_num2 = 3
+    off['detector_faces'] = sc.array(dims=['_', 'dummy'],
+                                     values=[[0, det_num2], [1, det_num1]],
+                                     unit=None)
+    loaded = off[()]
+    with pytest.raises(NexusStructureError):
+        off_to_shape(**loaded)
+
+
 def test_off_to_shape_with_single_detector_yields_1d_shape(nxroot):
     off = nxroot['entry'].create_class('off', NXoff_geometry)
     values = [[1, 2, 3], [4, 5, 6], [7, 8, 9]]
@@ -62,12 +78,18 @@ def test_off_to_shape_with_single_detector_yields_1d_shape(nxroot):
                                      values=[[0, det_num1], [1, det_num1]],
                                      unit=None)
     loaded = off[()]
-    shape = off_to_shape(**loaded)
-    assert shape.sizes == {'detector_number': 1}
-    assert sc.identical(
-        shape.coords['detector_number'],
-        sc.array(dims=['detector_number'], values=[det_num1], unit=None))
-    assert sc.identical(shape.bins.size().data,
+
+    detector_number = sc.index(1)  # not in detector_faces => no faces
+    shape = off_to_shape(**loaded, detector_number=detector_number)
+    assert sc.identical(shape.bins.size(), sc.array(dims=[], values=0, unit=None))
+
+    detector_number = sc.index(det_num1)
+    shape = off_to_shape(**loaded, detector_number=detector_number)
+    assert sc.identical(shape.bins.size(), sc.array(dims=[], values=2, unit=None))
+
+    detector_number = sc.array(dims=['detector_number'], values=[det_num1], unit=None)
+    shape = off_to_shape(**loaded, detector_number=detector_number)
+    assert sc.identical(shape.bins.size(),
                         sc.array(dims=['detector_number'], values=[2], unit=None))
 
 
@@ -83,15 +105,36 @@ def test_off_to_shape_with_two_detectors_yields_1d_shape(nxroot):
                                      values=[[0, det_num2], [1, det_num1]],
                                      unit=None)
     loaded = off[()]
-    shape = off_to_shape(**loaded)
+    detector_number = sc.array(dims=['detector_number'],
+                               values=[det_num1, det_num2],
+                               unit=None)
+    shape = off_to_shape(**loaded, detector_number=detector_number)
     assert shape.sizes == {'detector_number': 2}
-    assert sc.identical(shape.bins.size().data,
+    assert sc.identical(shape.bins.size(),
                         sc.array(dims=['detector_number'], values=[1, 1], unit=None))
-    assert sc.identical(
-        shape.coords['detector_number'],
-        sc.array(dims=['detector_number'], values=[det_num1, det_num2], unit=None))
     assert sc.identical(
         shape[0].value,
         sc.vectors(dims=['face', 'vertex'], values=[values[[0, 2, 1]]], unit='m'))
     assert sc.identical(shape[1].value,
                         sc.vectors(dims=['face', 'vertex'], values=[values], unit='m'))
+
+
+def test_off_to_shape_uses_order_of_provided_detector_number_param(nxroot):
+    off = nxroot['entry'].create_class('off', NXoff_geometry)
+    values = np.array([[1, 2, 3], [4, 5, 6], [7, 8, 9]])
+    off['vertices'] = sc.array(dims=['_', 'comp'], values=values, unit='m')
+    off['winding_order'] = sc.array(dims=['_'], values=[0, 1, 2, 0, 2, 1], unit=None)
+    off['faces'] = sc.array(dims=['_'], values=[0, 3], unit=None)
+    det_num1 = 1
+    det_num2 = 3
+    off['detector_faces'] = sc.array(dims=['_', 'dummy'],
+                                     values=[[0, det_num2], [1, det_num1]],
+                                     unit=None)
+    loaded = off[()]
+    detector_number = sc.array(dims=['detector_number'], values=[3, 1], unit=None)
+    shape = off_to_shape(**loaded, detector_number=detector_number)
+    assert sc.identical(shape[0].value,
+                        sc.vectors(dims=['face', 'vertex'], values=[values], unit='m'))
+    assert sc.identical(
+        shape[1].value,
+        sc.vectors(dims=['face', 'vertex'], values=[values[[0, 2, 1]]], unit='m'))

--- a/tests/nxoff_geometry_test.py
+++ b/tests/nxoff_geometry_test.py
@@ -1,8 +1,10 @@
 import h5py
+import numpy as np
 import pytest
 import scipp as sc
 
 from scippnexus import NXentry, NXoff_geometry, NXroot
+from scippnexus.nxoff_geometry import off_to_shape
 
 
 @pytest.fixture()
@@ -35,3 +37,61 @@ def test_field_properties(nxroot):
     assert loaded['winding_order'].unit is None
     assert loaded['faces'].dims == ('face', )
     assert loaded['faces'].unit is None
+
+
+def test_off_to_shape_without_detector_faces_yields_scalar_shape_with_all_faces(nxroot):
+    off = nxroot['entry'].create_class('off', NXoff_geometry)
+    values = [[1, 2, 3], [4, 5, 6], [7, 8, 9]]
+    off['vertices'] = sc.array(dims=['_', 'comp'], values=values, unit='m')
+    off['winding_order'] = sc.array(dims=['_'], values=[0, 1, 2, 0, 2, 1], unit=None)
+    off['faces'] = sc.array(dims=['_'], values=[0, 3], unit=None)
+    loaded = off[()]
+    shape = off_to_shape(**loaded)
+    assert shape.ndim == 0
+    assert sc.identical(shape.bins.size(), sc.index(2))
+
+
+def test_off_to_shape_with_single_detector_yields_1d_shape(nxroot):
+    off = nxroot['entry'].create_class('off', NXoff_geometry)
+    values = [[1, 2, 3], [4, 5, 6], [7, 8, 9]]
+    off['vertices'] = sc.array(dims=['_', 'comp'], values=values, unit='m')
+    off['winding_order'] = sc.array(dims=['_'], values=[0, 1, 2, 0, 2, 1], unit=None)
+    off['faces'] = sc.array(dims=['_'], values=[0, 3], unit=None)
+    det_num1 = 7
+    off['detector_faces'] = sc.array(dims=['_', 'dummy'],
+                                     values=[[0, det_num1], [1, det_num1]],
+                                     unit=None)
+    loaded = off[()]
+    shape = off_to_shape(**loaded)
+    assert shape.sizes == {'detector_number': 1}
+    assert sc.identical(
+        shape.coords['detector_number'],
+        sc.array(dims=['detector_number'], values=[det_num1], unit=None))
+    assert sc.identical(shape.bins.size().data,
+                        sc.array(dims=['detector_number'], values=[2], unit=None))
+
+
+def test_off_to_shape_with_two_detectors_yields_1d_shape(nxroot):
+    off = nxroot['entry'].create_class('off', NXoff_geometry)
+    values = np.array([[1, 2, 3], [4, 5, 6], [7, 8, 9]])
+    off['vertices'] = sc.array(dims=['_', 'comp'], values=values, unit='m')
+    off['winding_order'] = sc.array(dims=['_'], values=[0, 1, 2, 0, 2, 1], unit=None)
+    off['faces'] = sc.array(dims=['_'], values=[0, 3], unit=None)
+    det_num1 = 1
+    det_num2 = 3
+    off['detector_faces'] = sc.array(dims=['_', 'dummy'],
+                                     values=[[0, det_num2], [1, det_num1]],
+                                     unit=None)
+    loaded = off[()]
+    shape = off_to_shape(**loaded)
+    assert shape.sizes == {'detector_number': 2}
+    assert sc.identical(shape.bins.size().data,
+                        sc.array(dims=['detector_number'], values=[1, 1], unit=None))
+    assert sc.identical(
+        shape.coords['detector_number'],
+        sc.array(dims=['detector_number'], values=[det_num1, det_num2], unit=None))
+    assert sc.identical(
+        shape[0].value,
+        sc.vectors(dims=['face', 'vertex'], values=[values[[0, 2, 1]]], unit='m'))
+    assert sc.identical(shape[1].value,
+                        sc.vectors(dims=['face', 'vertex'], values=[values], unit='m'))


### PR DESCRIPTION
Improves loading of `NXoff_geometry` and `NXcylindrical_geometry`.

When such a group is loaded directly, the fields are loaded as-is. When embedded in, e.g., an NXdetector, its detector_numbers may be used to derive a shape for each detector pixel. This ensuresthat this can be tracked and broadcasted (e.g., against pixel offsets) properly, avoiding need to wrap in a scalar variable, which would prevent this.

This work has highlighted the need for butter support for "structured" dtypes in Scipp, see scipp/scipp#3046. For now, this is using binned data for a similar (if slightly more restricted) approach.