### PR TITLE
pyproject.toml missing in conda test env

### DIFF
--- a/conda/meta.yaml
+++ b/conda/meta.yaml
@@ -21,6 +21,7 @@ test:
   requires:
     - pytest
   source_files:
+    - pyproject.toml
     - tests/
   commands:
     - python -m pytest tests


### PR DESCRIPTION
This meant that pytest options were not used in the 'test' step of conda build.