### PR TITLE
More refined exception handling for fallback loader

### DIFF
--- a/src/scippnexus/_common.py
+++ b/src/scippnexus/_common.py
@@ -56,7 +56,7 @@ def _to_canonical_select(dims: List[str],
 
     def check_1d():
         if len(dims) != 1:
-            raise ValueError(f"Dataset has multiple dimensions {dims}, "
+            raise IndexError(f"Dataset has multiple dimensions {dims}, "
                              "specify the dimension to index.")
 
     if select is Ellipsis:
@@ -69,14 +69,14 @@ def _to_canonical_select(dims: List[str],
     if isinstance(select, tuple):
         check_1d()
         if len(select) != 1:
-            raise ValueError(f"Dataset has single dimension {dims}, "
+            raise IndexError(f"Dataset has single dimension {dims}, "
                              "but multiple indices {select} were specified.")
         return {dims[0]: select[0]}
     elif isinstance(select, int) or isinstance(select, slice):
         check_1d()
         return {dims[0]: select}
     if not isinstance(select, dict):
-        raise ValueError(f"Cannot process index {select}.")
+        raise IndexError(f"Cannot process index {select}.")
     return select
 
 
@@ -88,7 +88,7 @@ def to_plain_index(dims: List[str], select: ScippIndex) -> Union[int, slice, tup
     index = [slice(None)] * len(dims)
     for key, sel in select.items():
         if key not in dims:
-            raise ValueError(
+            raise IndexError(
                 f"'{key}' used for indexing not found in dataset dims {dims}.")
         index[dims.index(key)] = sel
     if len(index) == 1:

--- a/src/scippnexus/_common.py
+++ b/src/scippnexus/_common.py
@@ -56,8 +56,8 @@ def _to_canonical_select(dims: List[str],
 
     def check_1d():
         if len(dims) != 1:
-            raise IndexError(f"Dataset has multiple dimensions {dims}, "
-                             "specify the dimension to index.")
+            raise sc.DimensionError(f"Dataset has multiple dimensions {dims}, "
+                                    "specify the dimension to index.")
 
     if select is Ellipsis:
         return {}
@@ -69,8 +69,8 @@ def _to_canonical_select(dims: List[str],
     if isinstance(select, tuple):
         check_1d()
         if len(select) != 1:
-            raise IndexError(f"Dataset has single dimension {dims}, "
-                             "but multiple indices {select} were specified.")
+            raise sc.DimensionError(f"Dataset has single dimension {dims}, "
+                                    "but multiple indices {select} were specified.")
         return {dims[0]: select[0]}
     elif isinstance(select, int) or isinstance(select, slice):
         check_1d()
@@ -88,7 +88,7 @@ def to_plain_index(dims: List[str], select: ScippIndex) -> Union[int, slice, tup
     index = [slice(None)] * len(dims)
     for key, sel in select.items():
         if key not in dims:
-            raise IndexError(
+            raise sc.DimensionError(
                 f"'{key}' used for indexing not found in dataset dims {dims}.")
         index[dims.index(key)] = sel
     if len(index) == 1:

--- a/src/scippnexus/nxdata.py
+++ b/src/scippnexus/nxdata.py
@@ -278,6 +278,7 @@ class NXdata(NXobject):
                     da.coords[name] = coord
             except sc.DimensionError as e:
                 raise NexusStructureError(
-                    "Field in NXdata incompatible with dims or shape of signal.") from e
+                    f"Field in NXdata incompatible with dims or shape of signal: {e}"
+                ) from e
 
         return da

--- a/src/scippnexus/nxdata.py
+++ b/src/scippnexus/nxdata.py
@@ -137,6 +137,9 @@ class NXdata(NXobject):
         if self._signal_override is not None:
             return self._signal_override
         if self._signal_name is not None:
+            if self._signal_name not in self:
+                raise NexusStructureError(
+                    "Signal field '{self._signal_name}' not found in group.")
             return self[self._signal_name]
         return None
 

--- a/src/scippnexus/nxdata.py
+++ b/src/scippnexus/nxdata.py
@@ -266,11 +266,15 @@ class NXdata(NXobject):
             if (error_name := self._strategy.coord_errors(self, name)) is not None:
                 stddevs = asarray(self[error_name][sel])
                 coord.variances = sc.pow(stddevs, sc.scalar(2)).values
-            if self._coord_to_attr(da, name, field):
-                # Like scipp, slicing turns coord into attr if slicing removes the
-                # dim corresponding to the coord.
-                da.attrs[name] = coord
-            else:
-                da.coords[name] = coord
+            try:
+                if self._coord_to_attr(da, name, field):
+                    # Like scipp, slicing turns coord into attr if slicing removes the
+                    # dim corresponding to the coord.
+                    da.attrs[name] = coord
+                else:
+                    da.coords[name] = coord
+            except sc.DimensionError as e:
+                raise NexusStructureError(
+                    "Field in NXdata incompatible with dims or shape of signal.") from e
 
         return da

--- a/src/scippnexus/nxdata.py
+++ b/src/scippnexus/nxdata.py
@@ -228,7 +228,7 @@ class NXdata(NXobject):
         from .nexus_classes import NXgeometry
         signal = self._signal
         if signal is None:
-            raise NexusStructureError("No signal field found, cannot load group")
+            raise NexusStructureError("No signal field found, cannot load group.")
         signal = signal[select]
         if self._errors_name is not None:
             stddevs = self[self._errors_name][select]

--- a/src/scippnexus/nxdata.py
+++ b/src/scippnexus/nxdata.py
@@ -139,7 +139,7 @@ class NXdata(NXobject):
         if self._signal_name is not None:
             if self._signal_name not in self:
                 raise NexusStructureError(
-                    "Signal field '{self._signal_name}' not found in group.")
+                    f"Signal field '{self._signal_name}' not found in group.")
             return self[self._signal_name]
         return None
 

--- a/src/scippnexus/nxdetector.py
+++ b/src/scippnexus/nxdetector.py
@@ -99,7 +99,9 @@ class _EventField:
         return self._nxevent_data.unit
 
     def __getitem__(self, select: ScippIndex) -> sc.DataArray:
-        event_data: sc.DataArray = self._nxevent_data[self._event_select]
+        event_data = self._nxevent_data[self._event_select]
+        if isinstance(event_data, sc.DataGroup):
+            raise NexusStructureError("Invalid NXevent_data in NXdetector.")
         if self._grouping is None:
             if select not in (Ellipsis, tuple(), slice(None)):
                 raise NexusStructureError(

--- a/src/scippnexus/nxevent_data.py
+++ b/src/scippnexus/nxevent_data.py
@@ -121,7 +121,7 @@ class NXevent_data(NXobject):
         try:
             binned = sc.bins(data=events, dim=_event_dimension, begin=begins, end=ends)
         except IndexError as e:
-            raise IndexError(
+            raise NexusStructureError(
                 f"Invalid index in NXevent_data at {self.name}/event_index:\n{e}.")
 
         return sc.DataArray(data=binned, coords={'event_time_zero': event_time_zero})

--- a/src/scippnexus/nxmonitor.py
+++ b/src/scippnexus/nxmonitor.py
@@ -17,5 +17,5 @@ class NXmonitor(NXdetector):
         # binning present in the file (in NXevent_data) is preserved.
         return {
             'grouping_key': 'event_time_zero',
-            'grouping': self.events['event_time_zero']
+            'grouping': self.events.get('event_time_zero')
         }

--- a/src/scippnexus/nxobject.py
+++ b/src/scippnexus/nxobject.py
@@ -394,7 +394,7 @@ class NXobject:
         try:
             da = self._getitem(name)
             self._insert_leaf_properties(da)
-        except Exception as e:
+        except NexusStructureError as e:
             # If the child class cannot load this group, we fall back to returning the
             # underlying datasets in a DataGroup.
             if type(self)._getitem == NXobject._getitem:

--- a/src/scippnexus/nxobject.py
+++ b/src/scippnexus/nxobject.py
@@ -401,7 +401,7 @@ class NXobject:
                 raise
             else:
                 msg = (
-                    f"Failed to load {self.name} as {type(self).__name__}: {e}. "
+                    f"Failed to load {self.name} as {type(self).__name__}: {e} "
                     "Falling back to loading HDF5 group children as scipp.DataGroup.")
                 warnings.warn(msg)
             da = NXobject._getitem(self, name)

--- a/src/scippnexus/nxtransformations.py
+++ b/src/scippnexus/nxtransformations.py
@@ -28,11 +28,15 @@ class NXtransformations(NXobject):
     """Group of transformations."""
 
     def _getitem(self, index: ScippIndex) -> sc.DataGroup:
-        return sc.DataGroup({
-            name: get_full_transformation_starting_at(Transformation(child),
-                                                      index=index)
-            for name, child in self.items()
-        })
+        try:
+            return sc.DataGroup({
+                name: get_full_transformation_starting_at(Transformation(child),
+                                                          index=index)
+                for name, child in self.items()
+            })
+        except sc.UnitError as e:
+            raise NexusStructureError(
+                f"Invalid transformation in NXtransformations: {e}") from e
 
 
 class Transformation:

--- a/src/scippnexus/nxtransformations.py
+++ b/src/scippnexus/nxtransformations.py
@@ -9,10 +9,10 @@ import numpy as np
 import scipp as sc
 from scipp.scipy import interpolate
 
-from .nxobject import Field, NXobject, ScippIndex
+from .nxobject import Field, NexusStructureError, NXobject, ScippIndex
 
 
-class TransformationError(Exception):
+class TransformationError(NexusStructureError):
     pass
 
 

--- a/src/scippnexus/nxtransformations.py
+++ b/src/scippnexus/nxtransformations.py
@@ -34,7 +34,7 @@ class NXtransformations(NXobject):
                                                           index=index)
                 for name, child in self.items()
             })
-        except sc.UnitError as e:
+        except (sc.DimensionError, sc.UnitError) as e:
             raise NexusStructureError(
                 f"Invalid transformation in NXtransformations: {e}") from e
 

--- a/tests/nexus_test.py
+++ b/tests/nexus_test.py
@@ -97,6 +97,15 @@ def test_nxobject_log(nxroot):
     assert sc.identical(log[...], da)
 
 
+def test_nxlog_with_missing_value_triggers_fallback(nxroot):
+    time = sc.epoch(unit='ns') + sc.array(
+        dims=['time'], unit='s', values=[4.4, 5.5, 6.6]).to(unit='ns', dtype='int64')
+    log = nxroot['entry'].create_class('log', NXlog)
+    log['time'] = time - sc.epoch(unit='ns')
+    loaded = log[()]
+    assert sc.identical(loaded, sc.DataGroup(time=time.rename(time='dim_0')))
+
+
 def test_nxlog_length_1(nxroot):
     da = sc.DataArray(
         sc.array(dims=['time'], values=[1.1]),

--- a/tests/nxdata_test.py
+++ b/tests/nxdata_test.py
@@ -465,3 +465,16 @@ def test_nested_groups_trigger_fallback_to_load_as_data_group(nxroot):
     data.attrs['signal'] = 'signal'
     data.create_class('nested', NXdata)
     assert sc.identical(data[...], sc.DataGroup(signal=da.data, nested=sc.DataGroup()))
+
+
+def test_slicing_raises_given_invalid_index(nxroot):
+    signal = sc.array(dims=['xx', 'yy'], unit='m', values=[[1.1, 2.2], [3.3, 4.4]])
+    data = nxroot.create_class('data1', NXdata)
+    data.create_field('signal', signal)
+    data.attrs['axes'] = signal.dims
+    data.attrs['signal'] = 'signal'
+    assert sc.identical(data[...], sc.DataArray(signal))
+    with pytest.raises(IndexError):
+        data['xx', 2]
+    with pytest.raises(IndexError):
+        data['zz', 0]

--- a/tests/nxdata_test.py
+++ b/tests/nxdata_test.py
@@ -476,5 +476,5 @@ def test_slicing_raises_given_invalid_index(nxroot):
     assert sc.identical(data[...], sc.DataArray(signal))
     with pytest.raises(IndexError):
         data['xx', 2]
-    with pytest.raises(IndexError):
+    with pytest.raises(sc.DimensionError):
         data['zz', 0]

--- a/tests/nxdetector_test.py
+++ b/tests/nxdetector_test.py
@@ -265,7 +265,7 @@ def test_loading_event_data_with_selection_and_automatic_detector_numbers_raises
     detector = nxroot.create_class('detector0', NXdetector)
     create_event_data_ids_1234(detector.create_class('events', NXevent_data))
     assert detector.dims == ['detector_number']
-    with pytest.raises(ValueError):
+    with pytest.raises(IndexError):
         detector['detector_number', 0]
 
 

--- a/tests/nxdetector_test.py
+++ b/tests/nxdetector_test.py
@@ -265,7 +265,7 @@ def test_loading_event_data_with_selection_and_automatic_detector_numbers_raises
     detector = nxroot.create_class('detector0', NXdetector)
     create_event_data_ids_1234(detector.create_class('events', NXevent_data))
     assert detector.dims == ['detector_number']
-    with pytest.raises(IndexError):
+    with pytest.raises(sc.DimensionError):
         detector['detector_number', 0]
 
 


### PR DESCRIPTION
I am pretty sure this is not the last we will see of this: There are probably more places in the NXobject child classes that need to raise the right exception type. For now this works on the files in `pytest -m externalfiles` and a couple of others.

Fixes #107 