### PR TITLE
Improve handling of event data in NXdetector

### DIFF
--- a/src/scippnexus/_common.py
+++ b/src/scippnexus/_common.py
@@ -77,7 +77,7 @@ def _to_canonical_select(dims: List[str],
         return {dims[0]: select}
     if not isinstance(select, dict):
         raise IndexError(f"Cannot process index {select}.")
-    return select
+    return select.copy()
 
 
 def to_plain_index(dims: List[str], select: ScippIndex) -> Union[int, slice, tuple]:

--- a/src/scippnexus/v2/base.py
+++ b/src/scippnexus/v2/base.py
@@ -106,7 +106,7 @@ class NXobject:
         child_sel = to_child_select(tuple(self.sizes), child.dims, sel)
         return child[child_sel]
 
-    def read_children(self, obj: Group, sel: ScippIndex) -> sc.DataGroup:
+    def read_children(self, sel: ScippIndex) -> sc.DataGroup:
         """
         When a Group is indexed, this method is called to read all children.
 
@@ -347,7 +347,7 @@ class Group(Mapping):
                             and all(isclass(x) for x in sel)):
             return self._get_children_by_nx_class(sel)
 
-        dg = self._nexus.read_children(self, sel)
+        dg = self._nexus.read_children(sel)
         try:
             dg = self._nexus.assemble(dg)
         except (sc.DimensionError, NexusStructureError) as e:

--- a/src/scippnexus/v2/base.py
+++ b/src/scippnexus/v2/base.py
@@ -117,9 +117,10 @@ class NXobject:
         to implement special logic for reading children with interdependencies, i.e.,
         where reading each child in isolation is not possible.
         """
-        return sc.DataGroup(
-            {name: self.index_child(child, sel)
-             for name, child in obj.items()})
+        return sc.DataGroup({
+            name: self.index_child(child, sel)
+            for name, child in self._children.items()
+        })
 
     def assemble(self,
                  dg: sc.DataGroup) -> Union[sc.DataGroup, sc.DataArray, sc.Dataset]:

--- a/src/scippnexus/v2/nxdata.py
+++ b/src/scippnexus/v2/nxdata.py
@@ -86,7 +86,6 @@ class NXdata(NXobject):
         if name is not None and name in children:
             self._signal_name = name
             self._signal = children[name]
-            return
         # Legacy NXdata defines signal not as group attribute, but attr on dataset
         for name, field in children.items():
             # We ignore the signal value. Usually it is 1, but apparently one could
@@ -218,7 +217,12 @@ class NXdata(NXobject):
 
     @cached_property
     def sizes(self) -> Dict[str, int]:
-        return self._signal.sizes if self._valid else super().sizes
+        if not self._valid:
+            return super().sizes
+        sizes = dict(self._signal.sizes)
+        for name in self._aux_signals:
+            sizes.update(self._children[name].sizes)
+        return sizes
 
     @property
     def unit(self) -> Union[None, sc.Unit]:

--- a/src/scippnexus/v2/nxdata.py
+++ b/src/scippnexus/v2/nxdata.py
@@ -400,29 +400,6 @@ class NXdetector(NXdata):
                          fallback_dims=fallback_dims,
                          fallback_signal_name='data')
 
-    def xassemble(self,
-                  dg: sc.DataGroup) -> Union[sc.DataGroup, sc.DataArray, sc.Dataset]:
-        if self._valid:
-            obj = super().assemble(dg)
-        else:
-            obj = NXobject.assemble(self, dg)
-        if self._embedded_events is None:
-            return obj
-        # If events are embedded we are currently not including them in the `sizes`,
-        # so indexing is not possible. We could extend this in the future.
-        events = self._embedded_events[()]
-        if isinstance(events, sc.DataGroup):
-            if isinstance(obj, sc.DataArray):
-                return sc.DataGroup({self._signal_name: obj, 'events': events})
-            else:
-                obj.update(events)
-                return obj
-        if isinstance(obj, sc.DataArray):
-            return sc.Dataset({self._signal_name: obj, 'events': events})
-        else:
-            obj[uuid.uuid4().hex if 'events' in obj else 'events'] = events
-            return obj
-
     @property
     def detector_number(self) -> Optional[str]:
         return self._detector_number(self._children)

--- a/src/scippnexus/v2/nxdata.py
+++ b/src/scippnexus/v2/nxdata.py
@@ -392,12 +392,10 @@ class NXdetector(NXdata):
 
         children = {name: _maybe_event_field(child) for name, child in children.items()}
         if (event_group := _find_embedded_nxevent_data(children)) is not None:
-            signal = uuid.uuid4().hex if 'events' in children else 'events'
-            children[signal] = EventField(event_data=event_group,
-                                          grouping_name=det_num_name,
-                                          grouping=detector_number)
-        else:
-            signal = 'data'
+            name = uuid.uuid4().hex if 'events' in children else 'events'
+            children[name] = EventField(event_data=event_group,
+                                        grouping_name=det_num_name,
+                                        grouping=detector_number)
 
         super().__init__(attrs=attrs,
                          children=children,

--- a/src/scippnexus/v2/nxdata.py
+++ b/src/scippnexus/v2/nxdata.py
@@ -334,6 +334,19 @@ def _find_embedded_nxevent_data(
 class EventField:
 
     def __init__(self, event_data: Group, grouping_name: str, grouping: Field) -> None:
+        """Create a field that represents an event data group.
+
+        Parameters
+        ----------
+        event_data:
+            The event data group holding the NXevent_data fields.
+        grouping_name:
+            The name of the field that contains the grouping information.
+        grouping:
+            The field that contains the grouping keys. These are IDs corresponding to
+            the event_id field of the NXevent_data group, such as the detector_number
+            field of an NXdetector.
+        """
         self._event_data = event_data
         self._grouping_name = grouping_name
         self._grouping = grouping
@@ -344,9 +357,7 @@ class EventField:
 
     @property
     def sizes(self) -> Dict[str, int]:
-        sizes = dict(self._grouping.sizes)
-        sizes.update(self._event_data.sizes)
-        return sizes
+        return {**self._grouping.sizes, **self._event_data.sizes}
 
     @property
     def dims(self) -> Tuple[str, ...]:

--- a/src/scippnexus/v2/nxevent_data.py
+++ b/src/scippnexus/v2/nxevent_data.py
@@ -54,7 +54,8 @@ class NXevent_data(NXobject):
             return (_event_dimension, )
         return None
 
-    def read_children(self, children: Group, select: ScippIndex) -> sc.DataGroup:
+    def read_children(self, select: ScippIndex) -> sc.DataGroup:
+        children = self._children
         if not children:  # TODO Check that select is trivial?
             return sc.DataGroup()
 

--- a/src/scippnexus/v2/nxsample.py
+++ b/src/scippnexus/v2/nxsample.py
@@ -27,10 +27,10 @@ class NXsample(NXobject):
                 field.sizes = {k: field.sizes[k] for k in field.dims[:-2]}
                 field.dtype = sc.DType.linear_transform3
 
-    def read_children(self, obj: Group, sel: ScippIndex) -> sc.DataGroup:
+    def read_children(self, sel: ScippIndex) -> sc.DataGroup:
         return sc.DataGroup({
             name: _fix_unit(name, self.index_child(child, sel))
-            for name, child in obj.items()
+            for name, child in self._children.items()
         })
 
 

--- a/tests/nxdetector_test.py
+++ b/tests/nxdetector_test.py
@@ -66,8 +66,10 @@ def test_loads_signal_and_events_when_both_found(nxroot):
     events.create_field('event_time_offset', sc.array(dims=[''], unit='s', values=[1]))
     events.create_field('event_time_zero', sc.array(dims=[''], unit='s', values=[1]))
     events.create_field('event_index', sc.array(dims=[''], unit='None', values=[0]))
+    assert detector.sizes == {'detector_number': 2, 'event_time_zero': 1}
     loaded = detector[...]
-    assert_identical(loaded['data'], data)
+    assert isinstance(loaded, sc.Dataset)
+    assert_identical(loaded['data'].data, data)
     assert loaded['events'].bins is not None
 
 
@@ -216,6 +218,26 @@ def test_loads_event_data_with_2d_detector_numbers(nxroot):
                  unit=None,
                  dtype='int64',
                  values=[[2, 3], [0, 1]]))
+
+
+def test_selecting_pixels_works_with_event_signal(nxroot):
+    detector = nxroot.create_class('detector0', NXdetector)
+    detector.create_field('detector_number', detector_numbers_xx_yy_1234())
+    create_event_data_ids_1234(detector.create_class('events', snx.NXevent_data))
+    assert detector.sizes == {'dim_0': 2, 'dim_1': 2, 'event_time_zero': 4}
+    da = detector['dim_0', 0]
+    assert_identical(da.bins.size().data,
+                     sc.array(dims=['dim_1'], unit=None, dtype='int64', values=[2, 3]))
+
+
+def test_selecting_pixels_works_with_embedded_event_signal(nxroot):
+    detector = nxroot.create_class('detector0', NXdetector)
+    detector.create_field('detector_number', detector_numbers_xx_yy_1234())
+    create_event_data_ids_1234(detector)
+    assert detector.sizes == {'dim_0': 2, 'dim_1': 2, 'event_time_zero': 4}
+    da = detector['dim_0', 0]
+    assert_identical(da.bins.size().data,
+                     sc.array(dims=['dim_1'], unit=None, dtype='int64', values=[2, 3]))
 
 
 def test_select_events_slices_underlying_event_data(nxroot):

--- a/tests/nxdetector_test.py
+++ b/tests/nxdetector_test.py
@@ -173,19 +173,20 @@ def create_event_data_ids_1234(group):
 
 
 def test_loads_event_data_mapped_to_detector_numbers_based_on_their_event_id(nxroot):
-    detector_numbers = sc.array(dims=[''], unit=None, values=np.array([1, 2, 3, 4]))
+    detector_numbers = sc.array(dims=[''],
+                                unit=None,
+                                values=np.array([1, 2, 3, 4, 5, 6]))
     detector = nxroot.create_class('detector0', NXdetector)
     detector.create_field('detector_number', detector_numbers)
     create_event_data_ids_1234(detector.create_class('events', snx.NXevent_data))
-    assert detector.sizes == {'detector_number': 4, 'event_time_zero': 4}
-    loaded = detector[...]
-    da = snx.group_events_by_detector_number(loaded)
+    assert detector.sizes == {'detector_number': 6, 'event_time_zero': 4}
+    da = detector[...]
     assert sc.identical(
         da.bins.size().data,
         sc.array(dims=['detector_number'],
                  unit=None,
                  dtype='int64',
-                 values=[2, 3, 0, 1]))
+                 values=[2, 3, 0, 1, 0, 0]))
     assert 'event_time_offset' in da.bins.coords
     assert 'event_time_zero' in da.bins.coords
 
@@ -196,8 +197,8 @@ def test_loads_event_data_with_0d_detector_numbers(nxroot):
     create_event_data_ids_1234(detector.create_class('events', snx.NXevent_data))
     assert detector.dims == ('event_time_zero', )
     assert detector.shape == (4, )
-    loaded = snx.group_events_by_detector_number(detector[...])
-    assert sc.identical(loaded.bins.size().data, sc.index(2, dtype='int64'))
+    da = detector[...]
+    assert sc.identical(da.bins.size().data, sc.index(2, dtype='int64'))
 
 
 def test_loads_event_data_with_2d_detector_numbers(nxroot):
@@ -205,9 +206,9 @@ def test_loads_event_data_with_2d_detector_numbers(nxroot):
     detector.create_field('detector_number', detector_numbers_xx_yy_1234())
     create_event_data_ids_1234(detector.create_class('events', snx.NXevent_data))
     assert detector.sizes == {'dim_0': 2, 'dim_1': 2, 'event_time_zero': 4}
-    loaded = snx.group_events_by_detector_number(detector[...])
+    da = detector[...]
     assert sc.identical(
-        loaded.bins.size().data,
+        da.bins.size().data,
         sc.array(dims=['dim_0', 'dim_1'],
                  unit=None,
                  dtype='int64',
@@ -218,28 +219,28 @@ def test_select_events_slices_underlying_event_data(nxroot):
     detector = nxroot.create_class('detector0', NXdetector)
     detector.create_field('detector_number', detector_numbers_xx_yy_1234())
     create_event_data_ids_1234(detector.create_class('events', snx.NXevent_data))
-    da = snx.group_events_by_detector_number(detector['event_time_zero', :2])
+    da = detector['event_time_zero', :2]
     assert sc.identical(
         da.bins.size().data,
         sc.array(dims=['dim_0', 'dim_1'],
                  unit=None,
                  dtype='int64',
                  values=[[1, 1], [0, 1]]))
-    da = snx.group_events_by_detector_number(detector['event_time_zero', :3])
+    da = detector['event_time_zero', :3]
     assert sc.identical(
         da.bins.size().data,
         sc.array(dims=['dim_0', 'dim_1'],
                  unit=None,
                  dtype='int64',
                  values=[[2, 2], [0, 1]]))
-    da = snx.group_events_by_detector_number(detector['event_time_zero', 3])
+    da = detector['event_time_zero', 3]
     assert sc.identical(
         da.bins.size().data,
         sc.array(dims=['dim_0', 'dim_1'],
                  unit=None,
                  dtype='int64',
                  values=[[0, 1], [0, 0]]))
-    da = snx.group_events_by_detector_number(detector[()])
+    da = detector[()]
     assert sc.identical(
         da.bins.size().data,
         sc.array(dims=['dim_0', 'dim_1'],
@@ -248,16 +249,17 @@ def test_select_events_slices_underlying_event_data(nxroot):
                  values=[[2, 3], [0, 1]]))
 
 
-def test_loading_event_data_creates_automatic_detector_numbers_if_not_present_in_file(
-        nxroot):
+def test_loading_event_data_without_detector_numbers_does_not_group_events(nxroot):
     detector = nxroot.create_class('detector0', NXdetector)
     create_event_data_ids_1234(detector.create_class('events', snx.NXevent_data))
     assert detector.dims == ('event_time_zero', )
-    loaded = detector[...]
-    loaded = snx.group_events_by_detector_number(loaded)
-    assert sc.identical(
-        loaded.bins.size().data,
-        sc.array(dims=['event_id'], unit=None, dtype='int64', values=[2, 3, 1]))
+    da = detector[...]
+    assert_identical(
+        da.bins.size().data,
+        sc.array(dims=['event_time_zero'],
+                 unit=None,
+                 dtype='int64',
+                 values=[3, 0, 2, 1]))
 
 
 def test_loading_event_data_with_det_selection_and_automatic_detector_numbers_raises(

--- a/tests/nxdetector_test.py
+++ b/tests/nxdetector_test.py
@@ -71,7 +71,7 @@ def test_loads_signal_and_events_when_both_found(nxroot):
     assert loaded['events'].bins is not None
 
 
-def test_loads_embedded_events_as_subgroup(nxroot):
+def test_loads_as_data_array_with_embedded_events(nxroot):
     detector_number = sc.array(dims=[''], unit=None, values=np.array([1, 2, 3]))
     detector = nxroot.create_class('detector0', NXdetector)
     detector.create_field('detector_number', detector_number)
@@ -80,12 +80,15 @@ def test_loads_embedded_events_as_subgroup(nxroot):
                                                         values=[1]))
     detector.create_field('event_time_zero', sc.array(dims=[''], unit='s', values=[1]))
     detector.create_field('event_index', sc.array(dims=[''], unit='None', values=[0]))
-    loaded = detector[...]
-    assert_identical(loaded['detector_number'],
-                     detector_number.rename({'': 'detector_number'}))
-    assert loaded['events'].bins is not None
-    event_data = snx.group_events_by_detector_number(loaded)
-    assert event_data.sizes == {'detector_number': 3}
+    assert detector.dims == ('detector_number', 'event_time_zero')
+    da = detector[...]
+    assert da.bins is not None
+    assert_identical(
+        da.bins.size(),
+        sc.DataArray(
+            data=sc.array(dims=['detector_number'], unit=None, values=[1, 0, 0]),
+            coords={'detector_number': detector_number.rename({'':
+                                                               'detector_number'})}))
 
 
 def detector_numbers_xx_yy_1234():

--- a/tests/nxmonitor_test.py
+++ b/tests/nxmonitor_test.py
@@ -46,7 +46,7 @@ def create_event_data_no_ids(group):
                                                values=[0, 3, 3, 5]))
 
 
-def test_loads_event_data_in_current_group(group):
+def test_loads_event_data_in_current_group_as_data_array(group):
     monitor = group.create_class('monitor1', snx.NXmonitor)
     create_event_data_no_ids(monitor)
     assert monitor.dims == ('event_time_zero', )
@@ -60,14 +60,15 @@ def test_loads_event_data_in_current_group(group):
                  values=[3, 0, 2, 1]))
 
 
-def test_loads_event_data_in_child_group(group):
+def test_loads_event_data_in_child_group_as_data_array(group):
     monitor = group.create_class('monitor1', snx.NXmonitor)
     create_event_data_no_ids(monitor.create_class('events', snx.NXevent_data))
     assert monitor.dims == ('event_time_zero', )
     assert monitor.shape == (4, )
     loaded = monitor[...]
+    assert isinstance(loaded, sc.DataArray)
     assert sc.identical(
-        loaded['events'].bins.size().data,
+        loaded.bins.size().data,
         sc.array(dims=['event_time_zero'],
                  unit=None,
                  dtype='int64',


### PR DESCRIPTION
This resolves a number of inconsistencies and broken things. For example, slicing pixels works now. Behavior wise, we are now closer to the pre-v2 implementation.

When an NXdetector contains both dense data and events, this is not returning a `Dataset`. I don't know if this is useful in practice, or if we should just go back to returning the events by default?