### PR TITLE
Update docs to use `scippnexus.v2`

### DIFF
--- a/docs/getting-started/quick-start-guide.ipynb
+++ b/docs/getting-started/quick-start-guide.ipynb
@@ -64,7 +64,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "import scippnexus as snx\n",
+    "# To use the legacy interface, use:\n",
+    "# import scippnexus as snx\n",
+    "import scippnexus.v2 as snx\n",
     "\n",
     "with snx.File(filename) as f:\n",
     "    print(list(f.keys()))"
@@ -98,43 +100,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "067bfa30-b0b6-4c1d-bccd-438ab2789f6c",
-   "metadata": {},
-   "source": [
-    "### `NX_class`-based access\n",
-    "\n",
-    "When there is a unique child group with a specific `NX_class` attribute then this child can be accessed using a special property.\n",
-    "This avoids the need to know about and inspect the keys recursively.\n",
-    "For example, our file contains a single `NXentry`, which in turn contains a single `NXmonitor`.\n",
-    "We can access it using:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "b253b90d-269b-42ae-a236-e91d91ee1b8b",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "f.entry.monitor"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "1e673371-09a2-4f97-8797-44f13e884a3a",
-   "metadata": {},
-   "source": [
-    "<div class=\"alert alert-info\">\n",
-    "    <b>Note:</b>\n",
-    "\n",
-    "The property names are based on the value of `NX_class` attribute (without the \"NX\" prefix), *not* the HDF5 group name.\n",
-    "For example, above we used `f.entry.monitor` to access the monitor named `monitor1`.\n",
-    "\n",
-    "</div>"
-   ]
-  },
-  {
-   "cell_type": "markdown",
    "id": "a14fa902-5eae-4530-a8b4-3648da9ffea0",
    "metadata": {},
    "source": [
@@ -152,7 +117,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "entry = f['entry']  # equivalent to f.entry, since f contains only a single NXentry\n",
+    "entry = f['entry']\n",
     "entry"
    ]
   },
@@ -194,9 +159,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from scippnexus import NXdetector\n",
-    "\n",
-    "f.entry.instrument[NXdetector]"
+    "f['entry/instrument'][snx.NXdetector]"
    ]
   },
   {

--- a/docs/user-guide/application-definitions.ipynb
+++ b/docs/user-guide/application-definitions.ipynb
@@ -36,6 +36,22 @@
   },
   {
    "cell_type": "markdown",
+   "id": "7fc1d425-4a31-4b75-87d4-f0398b88c090",
+   "metadata": {},
+   "source": [
+    "Definitions provide customization points, e.g., for how ScippNexus can find required information in the HDF5 group, and how contents are mapped to aspects of the returned data (typically a `scipp.DataArray` or `scipp.DataGroup`).\n",
+    "\n",
+    "Definitions in ScippNexus are subclasses of [NXobject](classes.rst#NXobject).\n",
+    "A `definitions` mapping passed to `snx.File` serves as a repository of definitions that `snx.Group` will use when opening a group in a file.\n",
+    "`snx.base_definitions` is used by default.\n",
+    "The `NX_class` attribute of the HDF5 group is used as a key into the `definitions` mapping.\n",
+    "It provides subclasses such as `NXlog`, `NXdata`, and `NXdetector`.\n",
+    "\n",
+    "Users can implement their application definition (or any definition) by subclassing `NXobject`, or one of the existing base-class definitions."
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "c4164b2f-6e64-4a9f-8204-daf6ef8025fc",
    "metadata": {},
    "source": [
@@ -46,10 +62,10 @@
     "The requirements are that the value\n",
     "\n",
     "1. provides an `nx_class` attribute that returns a valid NeXus class name such as `'NXdata'` or `scippnexus.NXdata` and\n",
-    "2. defines the `__write_to_nexus_group__` method that takes a `scippnexus.NXobject`, i.e., an open NeXus group, as its single argument.\n",
+    "2. defines the `__write_to_nexus_group__` method that takes a `h5py.Group`, i.e., an open HDF5 group, as its single argument.\n",
     "\n",
     "`__write_to_nexus_group__` may then write its content to this group.\n",
-    "This can (and should) make use of ScippNexus features for writing Nexus fields (HDF5 datasets), such as automatic writing of the `units` attribute, or writing `datetime64` data.\n",
+    "This can (and should) make use of ScippNexus features for writing Nexus fields (HDF5 datasets) from a `scipp.Variable` via `snx.create_field`, such as automatic writing of the `units` attribute, or writing `datetime64` data.\n",
     "Consider the following example:"
    ]
   },
@@ -60,8 +76,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "import h5py\n",
     "import scipp as sc\n",
-    "import scippnexus as snx\n",
+    "import scippnexus.v2 as snx\n",
     "\n",
     "\n",
     "class MyData:\n",
@@ -70,9 +87,9 @@
     "    def __init__(self, data: sc.DataArray):\n",
     "        self._data = data\n",
     "\n",
-    "    def __write_to_nexus_group__(self, group: snx.NXobject):  # required\n",
+    "    def __write_to_nexus_group__(self, group: h5py.Group):  # required\n",
     "        group.attrs['axes'] = self._data.dims  # NeXus way of defining dim labels\n",
-    "        group['mysignal'] = self._data.data"
+    "        snx.create_field(group, 'mysignal', self._data.data)"
    ]
   },
   {
@@ -112,11 +129,11 @@
     "This is the case when the application definition follows the NeXus standard and, e.g., introduces no new attributes.\n",
     "\n",
     "In other cases we require customization of how ScippNexus reads class contents.\n",
-    "On the lowest level, this is handled using *strategies* that can be passed to `scippnexus.NXobject` and its subclasses such as `scippnexus.NXdata`.\n",
-    "Handling of strategies is usually encapsulated by a *definition* that can be passed to `scippnexus.File`.\n",
+    "This is handled using *definitions* that can be passed to `snx.File` or `snx.Group`.\n",
     "\n",
-    "As an example, consider the following simple strategy for loading data with a custom signal name, which the file failed to specify.\n",
-    "We also subclass `scippnexus.ApplicationDefinition`:"
+    "As an example, consider the following simple definition for loading data with a custom signal name, which the file failed to specify.\n",
+    "In this particular case we subclass `snx.NXdata`, and pass a custom argument to its `__init__`.\n",
+    "In general this is rarely sufficient, and in practice a definition may need to implement other parts of the `snx.NXobject` interface:"
    ]
   },
   {
@@ -126,16 +143,13 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "class MyDataStrategy(snx.NXdataStrategy):\n",
-    "    @staticmethod\n",
-    "    def signal(group: snx.NXobject) -> str:\n",
-    "        return 'mysignal'\n",
+    "class MyDataDefinition(snx.NXdata):\n",
+    "    def __init__(self, attrs, children):\n",
+    "        super().__init__(attrs=attrs, children=children, fallback_signal_name='mysignal')\n",
     "\n",
     "\n",
-    "class MyDefinition(snx.ApplicationDefinition):\n",
-    "    def make_strategy(self, group: snx.NXobject):\n",
-    "        if group.nx_class == snx.NXdata:\n",
-    "            return MyDataStrategy"
+    "my_definitions = dict(snx.base_definitions)\n",
+    "my_definitions['NXdata'] = MyDataDefinition"
    ]
   },
   {
@@ -143,7 +157,7 @@
    "id": "ef933561-9e32-4549-acd1-1b574b585742",
    "metadata": {},
    "source": [
-    "We can then load our file (created above in [Writing files](#Writing-files)) by passing an instance of our custom definition to `scippnexus.File`:"
+    "We can then load our file (created above in [Writing files](#Writing-files)) by our custom definitions to `snx.File`:"
    ]
   },
   {
@@ -153,7 +167,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "with snx.File('test.nxs', 'r', definition=MyDefinition()) as f:\n",
+    "with snx.File('test.nxs', 'r', definitions=my_definitions) as f:\n",
     "    loaded = f['data'][...]\n",
     "loaded"
    ]
@@ -164,29 +178,7 @@
    "metadata": {},
    "source": [
     "ScippNexus does currently not ship with a library of application definitions.\n",
-    "Custom definitions can be provided by a user as outlined above.\n",
-    "The *definition* passed to ScippNexus serves as a factory for strategies &mdash; in the above example the only custom definition is the one used for `NXdata`.\n",
-    "For a given group in a NeXus tree, ScippNexus calls `definition.make_strategy(group)` to request a strategy for the group.\n",
-    "This may return `None` and ScippNexus will then use its default strategy for loading the group.\n",
-    "\n",
-    "Strategies provide customization points, e.g., for how ScippNexus can find required information in the HDF5 group, and how contents are mapped to aspects of the returned data (typically a `scipp.DataArray`).\n",
-    "For example, the default `scippnexus.NXdataStrategy` provides a static `axes` method that returns the name of the axes in the group, i.e., the dimension labels.\n",
-    "Users can either subclass `NXdataStrategy`, or provide a class with equivalent interfaces.\n",
-    "A full list of available base strategies can be found in [Strategies](classes.rst#Strategies)."
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "69a0c1b7-2dc3-47c3-88d1-23cfc1ee77ac",
-   "metadata": {},
-   "source": [
-    "<div class=\"alert alert-info\">\n",
-    "    <b>Note:</b>\n",
-    "\n",
-    "Support for strategies is very new and the number of customization points is currently very limited.\n",
-    "If you encounter the need for more customization, please [open an issue](https://github.com/scipp/scippnexus/issues/new) so we can consider how to extent the base strategy.\n",
-    "\n",
-    "</div>"
+    "Custom definitions can be provided by a user as outlined above."
    ]
   },
   {
@@ -194,11 +186,11 @@
    "id": "2371d6ef-8ad3-4a2c-bc63-939d1a29950f",
    "metadata": {},
    "source": [
-    "### Using strategies for filtering\n",
+    "### Using definitions for filtering\n",
     "\n",
     "The application-definition mechanism can be used for filtering or selecting which children from a group should be loaded.\n",
     "For example, we may wish to exclude certain NeXus classes from loading.\n",
-    "We define a strategy as follows:"
+    "We define a custom definition as follows:"
    ]
   },
   {
@@ -208,19 +200,26 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "import scippnexus as snx\n",
+    "import scippnexus.v2 as snx\n",
     "\n",
     "\n",
-    "class FilterStrategy(snx.NXobjectStrategy):\n",
-    "    @staticmethod\n",
-    "    def include_child(group: snx.NXobject) -> bool:\n",
-    "        \"\"\"\n",
-    "        Skip all NXevent_data, the NXinstrument, and the group named \"DASlogs\".\n",
-    "        \"\"\"\n",
-    "        skip_classes = (snx.NXevent_data, snx.NXinstrument)\n",
-    "        if isinstance(group, skip_classes):\n",
-    "            return False\n",
-    "        return not group.name.endswith('DASlogs')"
+    "def skip(name, obj):\n",
+    "    skip_classes = (snx.NXevent_data, snx.NXinstrument)\n",
+    "    return isinstance(obj, snx.Group) and (\n",
+    "        (obj.nx_class in skip_classes) or (name == 'DASlogs')\n",
+    "    )\n",
+    "\n",
+    "\n",
+    "class FilteredEntry(snx.NXobject):\n",
+    "    def __init__(self, attrs, children):\n",
+    "        children = {\n",
+    "            name: child for name, child in children.items() if not skip(name, child)\n",
+    "        }\n",
+    "        super().__init__(attrs=attrs, children=children)\n",
+    "\n",
+    "\n",
+    "my_definitions = dict(snx.base_definitions)\n",
+    "my_definitions['NXentry'] = FilteredEntry"
    ]
   },
   {
@@ -228,7 +227,7 @@
    "id": "b95829c7-8d32-4731-9a99-361cdf8017cc",
    "metadata": {},
    "source": [
-    "We can use this strategy with a custom application definition as follows:"
+    "We can use these definitions as follows:"
    ]
   },
   {
@@ -241,17 +240,8 @@
     "from scippnexus import data\n",
     "\n",
     "filename = data.get_path('PG3_4844_event.nxs')\n",
-    "definition = snx.make_definition({snx.NXentry: FilterStrategy})\n",
-    "f = snx.File(filename, definition=definition)\n",
+    "f = snx.File(filename, definitions=my_definitions)\n",
     "f['entry'][...]"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "e054874a-df45-450d-9cb4-9b5b5ccff309",
-   "metadata": {},
-   "source": [
-    "Above we used the helper [snx.make_definition](../generated/functions/make_definition.rst) which can be used instead of manually subclassing `ApplicationDefinition` in such simple cases."
    ]
   }
  ],

--- a/docs/user-guide/application-definitions.ipynb
+++ b/docs/user-guide/application-definitions.ipynb
@@ -43,7 +43,7 @@
     "\n",
     "Definitions in ScippNexus are subclasses of [NXobject](classes.rst#NXobject).\n",
     "A `definitions` mapping passed to `snx.File` serves as a repository of definitions that `snx.Group` will use when opening a group in a file.\n",
-    "`snx.base_definitions` is used by default.\n",
+    "`snx.base_definitions()` is used by default.\n",
     "The `NX_class` attribute of the HDF5 group is used as a key into the `definitions` mapping.\n",
     "It provides subclasses such as `NXlog`, `NXdata`, and `NXdetector`.\n",
     "\n",
@@ -148,7 +148,7 @@
     "        super().__init__(attrs=attrs, children=children, fallback_signal_name='mysignal')\n",
     "\n",
     "\n",
-    "my_definitions = dict(snx.base_definitions)\n",
+    "my_definitions = snx.base_definitions()\n",
     "my_definitions['NXdata'] = MyDataDefinition"
    ]
   },
@@ -218,7 +218,7 @@
     "        super().__init__(attrs=attrs, children=children)\n",
     "\n",
     "\n",
-    "my_definitions = dict(snx.base_definitions)\n",
+    "my_definitions = snx.base_definitions()\n",
     "my_definitions['NXentry'] = FilteredEntry"
    ]
   },

--- a/docs/user-guide/classes.rst
+++ b/docs/user-guide/classes.rst
@@ -1,4 +1,4 @@
-.. currentmodule:: scippnexus
+.. currentmodule:: scippnexus.v2
 
 Classes
 =======
@@ -11,10 +11,10 @@ Data Structures
    :template: scipp-class-template.rst
    :recursive:
 
-   ApplicationDefinition
    Attrs
    Field
    File
+   Group
    NXaperture
    NXattenuator
    NXbeam
@@ -73,18 +73,6 @@ Data Structures
    NXvelocity_selector
    NXxraylens
 
-Strategies
-----------
-
-.. autosummary::
-   :toctree: ../generated/classes
-   :template: scipp-class-template.rst
-   :recursive:
-
-   NXdataStrategy
-   NXdetectorStrategy
-   NXlogStrategy
-
 Exceptions
 ----------
 
@@ -97,6 +85,8 @@ Exceptions
 
 Typing
 ------
+
+.. currentmodule:: scippnexus
 
 .. autosummary::
    :toctree: ../generated/classes

--- a/docs/user-guide/functions.rst
+++ b/docs/user-guide/functions.rst
@@ -1,4 +1,4 @@
-.. currentmodule:: scippnexus
+.. currentmodule:: scippnexus.v2
 
 Functions
 =========
@@ -6,4 +6,5 @@ Functions
 .. autosummary::
    :toctree: ../generated/functions
 
-   make_definition
+   create_field
+   create_class

--- a/docs/user-guide/nexus-classes.ipynb
+++ b/docs/user-guide/nexus-classes.ipynb
@@ -62,7 +62,7 @@
    "source": [
     "from scippnexus import data\n",
     "filename = data.get_path('PG3_4844_event.nxs')\n",
-    "import scippnexus as snx\n",
+    "import scippnexus.v2 as snx\n",
     "f = snx.File(filename)"
    ]
   },
@@ -174,7 +174,8 @@
    "id": "de532afe-6382-420b-bda4-4297172ffec5",
    "metadata": {},
    "source": [
-    "If the underlying data is event data, the underlying event data can be selected using the special `select_events` property.\n",
+    "If the underlying data is event data, the underlying event data can be selected using the special `event_time_zero` dimension.\n",
+    "This dimension is present in the underlying `NXevent_data` group, but not preserved after loading and binning by pixels due to the prohibitive size.\n",
     "For example, we can select the first 1000 pulses and load data for all pixels:"
    ]
   },
@@ -185,7 +186,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "detector.select_events['pulse', :1000][...]"
+    "detector['event_time_zero', :1000]"
    ]
   },
   {
@@ -246,7 +247,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "f['entry/instrument/bank102'].events[...]"
+    "f['entry/instrument/bank102']['events'][...]"
    ]
   },
   {

--- a/src/scippnexus/v2/__init__.py
+++ b/src/scippnexus/v2/__init__.py
@@ -19,7 +19,7 @@ from .base import (
     create_class,
     create_field,
 )
-from .field import Field
+from .field import Attrs, Field
 from .file import File
 from .nexus_classes import *
 from .nxdata import group_events_by_detector_number

--- a/src/scippnexus/v2/application_definitions/nxcansas/nxcansas.py
+++ b/src/scippnexus/v2/application_definitions/nxcansas/nxcansas.py
@@ -120,7 +120,7 @@ class NXcanSAS:
                     return _SASdata(attrs, children)
                 if cls == 'SAStransmission_spectrum':
                     return _SAStransmission_spectrum(attrs, children)
-            return base_definitions.get(key, default)(attrs, children)
+            return base_definitions().get(key, default)(attrs, children)
 
         return _definition_factory
 

--- a/src/scippnexus/v2/base.py
+++ b/src/scippnexus/v2/base.py
@@ -283,7 +283,7 @@ class Group(Mapping):
         select = tuple(select) if isinstance(select, list) else select
         for key, child in self._children.items():
             nx_class = Field if isinstance(child, Field) else child.nx_class
-            if issubclass(nx_class, select):
+            if nx_class is not None and issubclass(nx_class, select):
                 children[key] = self[key]
         return children
 

--- a/src/scippnexus/v2/base.py
+++ b/src/scippnexus/v2/base.py
@@ -452,4 +452,13 @@ def _nx_class_registry():
     return dict(inspect.getmembers(nexus_classes, inspect.isclass))
 
 
-base_definitions = {}
+base_definitions_dict = {}
+
+
+def base_definitions() -> Dict[str, type]:
+    """Return a dict of all base definitions.
+
+    This is a copy of the base definitions dict, so that it can be modified without
+    affecting the original.
+    """
+    return dict(base_definitions_dict)

--- a/src/scippnexus/v2/file.py
+++ b/src/scippnexus/v2/file.py
@@ -2,6 +2,7 @@
 # Copyright (c) 2023 Scipp contributors (https://github.com/scipp)
 # @author Simon Heybrock
 from contextlib import AbstractContextManager
+from typing import Mapping
 
 import h5py
 
@@ -10,7 +11,18 @@ from .base import Group, base_definitions
 
 class File(AbstractContextManager, Group):
 
-    def __init__(self, *args, definitions=base_definitions, **kwargs):
+    def __init__(self, *args, definitions: Mapping = base_definitions, **kwargs):
+        """Context manager for NeXus files, similar to h5py.File.
+
+        Arguments other than documented are as in :py:class:`h5py.File`.
+
+        Parameters
+        ----------
+        definitions:
+            Mapping of NX_class names to application-specific definitions.
+            The default is to use the base definitions as defined in the
+            NeXus standard.
+        """
         self._file = h5py.File(*args, **kwargs)
         super().__init__(self._file, definitions=definitions)
 

--- a/src/scippnexus/v2/file.py
+++ b/src/scippnexus/v2/file.py
@@ -8,10 +8,12 @@ import h5py
 
 from .base import Group, base_definitions
 
+_default_definitions = object()
+
 
 class File(AbstractContextManager, Group):
 
-    def __init__(self, *args, definitions: Mapping = base_definitions, **kwargs):
+    def __init__(self, *args, definitions: Mapping = _default_definitions, **kwargs):
         """Context manager for NeXus files, similar to h5py.File.
 
         Arguments other than documented are as in :py:class:`h5py.File`.
@@ -23,6 +25,8 @@ class File(AbstractContextManager, Group):
             The default is to use the base definitions as defined in the
             NeXus standard.
         """
+        if definitions is _default_definitions:
+            definitions = base_definitions()
         self._file = h5py.File(*args, **kwargs)
         super().__init__(self._file, definitions=definitions)
 

--- a/src/scippnexus/v2/nxcylindrical_geometry.py
+++ b/src/scippnexus/v2/nxcylindrical_geometry.py
@@ -5,7 +5,7 @@ from typing import Any, Dict, Optional, Union
 
 import scipp as sc
 
-from .base import Group, NexusStructureError, NXobject, base_definitions
+from .base import Group, NexusStructureError, NXobject, base_definitions_dict
 from .field import Field
 
 
@@ -71,4 +71,4 @@ class NXcylindrical_geometry(NXobject):
         return _parse(**children, parent_detector_number=detector_number)
 
 
-base_definitions['NXcylindrical_geometry'] = NXcylindrical_geometry
+base_definitions_dict['NXcylindrical_geometry'] = NXcylindrical_geometry

--- a/src/scippnexus/v2/nxdata.py
+++ b/src/scippnexus/v2/nxdata.py
@@ -260,7 +260,11 @@ class NXdata(NXobject):
         if aux:
             signals = {self._signal_name: da}
             signals.update(aux)
-            return sc.Dataset(signals)
+            if all(
+                    isinstance(v, (sc.Variable, sc.DataArray))
+                    for v in signals.values()):
+                return sc.Dataset(signals)
+            return sc.DataGroup(signals)
         return da
 
     def _dim_of_coord(self, name: str, coord: sc.Variable) -> Union[None, str]:

--- a/src/scippnexus/v2/nxdata.py
+++ b/src/scippnexus/v2/nxdata.py
@@ -12,7 +12,13 @@ import scipp as sc
 
 from .._common import convert_time_to_datetime64, to_child_select
 from ..typing import H5Dataset, ScippIndex
-from .base import Group, NexusStructureError, NXobject, asvariable, base_definitions
+from .base import (
+    Group,
+    NexusStructureError,
+    NXobject,
+    asvariable,
+    base_definitions_dict,
+)
 from .field import Field
 from .nxevent_data import NXevent_data
 
@@ -489,7 +495,7 @@ def group_events_by_detector_number(
     return out
 
 
-base_definitions['NXdata'] = NXdata
-base_definitions['NXlog'] = NXlog
-base_definitions['NXdetector'] = NXdetector
-base_definitions['NXmonitor'] = NXmonitor
+base_definitions_dict['NXdata'] = NXdata
+base_definitions_dict['NXlog'] = NXlog
+base_definitions_dict['NXdetector'] = NXdetector
+base_definitions_dict['NXmonitor'] = NXmonitor

--- a/src/scippnexus/v2/nxevent_data.py
+++ b/src/scippnexus/v2/nxevent_data.py
@@ -7,7 +7,13 @@ import numpy as np
 import scipp as sc
 
 from .._common import to_plain_index
-from .base import Group, NexusStructureError, NXobject, ScippIndex, base_definitions
+from .base import (
+    Group,
+    NexusStructureError,
+    NXobject,
+    ScippIndex,
+    base_definitions_dict,
+)
 from .field import Field
 
 _event_dimension = "event"
@@ -148,4 +154,4 @@ class NXevent_data(NXobject):
         return sc.DataArray(data=binned, coords={'event_time_zero': event_time_zero})
 
 
-base_definitions['NXevent_data'] = NXevent_data
+base_definitions_dict['NXevent_data'] = NXevent_data

--- a/src/scippnexus/v2/nxoff_geometry.py
+++ b/src/scippnexus/v2/nxoff_geometry.py
@@ -5,7 +5,7 @@ from typing import Any, Dict, Optional, Union
 
 import scipp as sc
 
-from .base import Group, NexusStructureError, NXobject, base_definitions
+from .base import Group, NexusStructureError, NXobject, base_definitions_dict
 from .field import Field
 
 
@@ -80,4 +80,4 @@ class NXoff_geometry(NXobject):
         return off_to_shape(**children, detector_number=detector_number)
 
 
-base_definitions['NXoff_geometry'] = NXoff_geometry
+base_definitions_dict['NXoff_geometry'] = NXoff_geometry

--- a/src/scippnexus/v2/nxsample.py
+++ b/src/scippnexus/v2/nxsample.py
@@ -5,7 +5,7 @@ from typing import Any, Dict, Union
 
 import scipp as sc
 
-from .base import Group, NXobject, ScippIndex, base_definitions
+from .base import Group, NXobject, ScippIndex, base_definitions_dict
 from .field import Field
 
 _matrix_units = {'orientation_matrix': 'one', 'ub_matrix': '1/Angstrom'}
@@ -34,4 +34,4 @@ class NXsample(NXobject):
         })
 
 
-base_definitions['NXsample'] = NXsample
+base_definitions_dict['NXsample'] = NXsample

--- a/tests/application_definition_test.py
+++ b/tests/application_definition_test.py
@@ -11,7 +11,7 @@ from scippnexus.v2.application_definitions import nxcansas
 def nxroot():
     """Yield NXroot containing a single NXentry named 'entry'"""
     with h5py.File('dummy.nxs', mode='w', driver="core", backing_store=False) as f:
-        root = snx.Group(f, definitions=snx.base_definitions)
+        root = snx.Group(f, definitions=snx.base_definitions())
         root.create_class('entry', snx.NXentry)
         yield root
 

--- a/tests/nexus_test.py
+++ b/tests/nexus_test.py
@@ -38,7 +38,7 @@ def h5root():
 def nxroot():
     """Yield NXroot containing a single NXentry named 'entry'"""
     with h5py.File('dummy.nxs', mode='w', driver="core", backing_store=False) as f:
-        root = snx.Group(f, definitions=snx.base_definitions)
+        root = snx.Group(f, definitions=snx.base_definitions())
         root.create_class('entry', NXentry)
         yield root
 
@@ -95,7 +95,7 @@ def test_nx_class_can_be_bytes(h5root):
     attr = np.chararray((), itemsize=5)
     attr[()] = b'NXlog'
     log.attrs['NX_class'] = attr
-    group = snx.Group(log, definitions=snx.base_definitions)
+    group = snx.Group(log, definitions=snx.base_definitions())
     assert group.nx_class == NXlog
 
 
@@ -110,7 +110,7 @@ def test_nxobject_log(h5root):
     log = snx.create_class(h5root, 'log', NXlog)
     snx.create_field(log, 'value', da.data)
     snx.create_field(log, 'time', da.coords['time'] - sc.epoch(unit='ns'))
-    log = snx.Group(log, definitions=snx.base_definitions)
+    log = snx.Group(log, definitions=snx.base_definitions())
     assert sc.identical(log[...], da)
 
 
@@ -125,7 +125,7 @@ def test_nxlog_with_missing_value_triggers_fallback(nxroot):
 
 
 def test_nxlog_length_1(h5root):
-    nxroot = snx.Group(h5root, definitions=snx.base_definitions)
+    nxroot = snx.Group(h5root, definitions=snx.base_definitions())
     da = sc.DataArray(
         sc.array(dims=['time'], values=[1.1]),
         coords={
@@ -539,7 +539,7 @@ def test_nxdata_with_signal_axes_indices_reads_as_data_array(h5root):
     data['time'].attrs['units'] = str(ref.coords['time'].unit)
     data['temperature'] = ref.coords['temperature'].values
     data['temperature'].attrs['units'] = str(ref.coords['temperature'].unit)
-    obj = snx.Group(data, definitions=snx.base_definitions)
+    obj = snx.Group(data, definitions=snx.base_definitions())
     da = obj[()]
     assert sc.identical(da, ref)
 
@@ -564,7 +564,7 @@ def test_nxdata_positional_indexing_returns_correct_slice(h5root):
     data['time'].attrs['units'] = str(ref.coords['time'].unit)
     data['temperature'] = ref.coords['temperature'].values
     data['temperature'].attrs['units'] = str(ref.coords['temperature'].unit)
-    obj = snx.Group(data, definitions=snx.base_definitions)
+    obj = snx.Group(data, definitions=snx.base_definitions())
     da = obj['time', 0:2]
     assert sc.identical(da, ref['time', 0:2])
 
@@ -589,6 +589,6 @@ def test_nxdata_with_bin_edges_positional_indexing_returns_correct_slice(h5root)
     data['time'].attrs['units'] = str(ref.coords['time'].unit)
     data['temperature'] = ref.coords['temperature'].values
     data['temperature'].attrs['units'] = str(ref.coords['temperature'].unit)
-    obj = snx.Group(data, definitions=snx.base_definitions)
+    obj = snx.Group(data, definitions=snx.base_definitions())
     da = obj['temperature', 0:2]
     assert sc.identical(da, ref['temperature', 0:2])

--- a/tests/nxcylindrical_geometry_test.py
+++ b/tests/nxcylindrical_geometry_test.py
@@ -9,7 +9,7 @@ import scippnexus.v2 as snx
 def nxroot():
     """Yield NXroot containing a single NXentry named 'entry'"""
     with h5py.File('dummy.nxs', mode='w', driver="core", backing_store=False) as f:
-        root = snx.Group(f, snx.base_definitions)
+        root = snx.Group(f, snx.base_definitions())
         root.create_class('entry', snx.NXentry)
         yield root
 

--- a/tests/nxdata_test.py
+++ b/tests/nxdata_test.py
@@ -19,7 +19,7 @@ def h5root():
 def nxroot():
     """Yield NXroot containing a single NXentry named 'entry'"""
     with h5py.File('dummy.nxs', mode='w', driver="core", backing_store=False) as f:
-        root = snx.Group(f, definitions=snx.base_definitions)
+        root = snx.Group(f, definitions=snx.base_definitions())
         root.create_class('entry', snx.NXentry)
         yield root
 
@@ -30,7 +30,7 @@ def test_without_coords(h5root):
     snx.create_field(data, 'signal', signal)
     data.attrs['axes'] = signal.dims
     data.attrs['signal'] = 'signal'
-    obj = snx.Group(data, definitions=snx.base_definitions)
+    obj = snx.Group(data, definitions=snx.base_definitions())
     assert sc.identical(obj[...], sc.DataArray(signal))
 
 
@@ -43,7 +43,7 @@ def test_with_coords_matching_axis_names(h5root):
     data.attrs['signal'] = 'signal'
     snx.create_field(data, 'signal', da.data)
     snx.create_field(data, 'xx', da.coords['xx'])
-    group = snx.Group(data, definitions=snx.base_definitions)
+    group = snx.Group(data, definitions=snx.base_definitions())
     assert sc.identical(group[...], da)
 
 
@@ -56,7 +56,7 @@ def test_guessed_dim_for_coord_not_matching_axis_name(h5root):
     data.attrs['signal'] = 'signal'
     snx.create_field(data, 'signal', da.data)
     snx.create_field(data, 'xx2', da.coords['xx2'])
-    data = snx.Group(data, definitions=snx.base_definitions)
+    data = snx.Group(data, definitions=snx.base_definitions())
     assert sc.identical(data[...], da)
 
 
@@ -73,7 +73,7 @@ def test_multiple_coords(h5root):
     snx.create_field(data, 'xx', da.coords['xx'])
     snx.create_field(data, 'xx2', da.coords['xx2'])
     snx.create_field(data, 'yy', da.coords['yy'])
-    data = snx.Group(data, definitions=snx.base_definitions)
+    data = snx.Group(data, definitions=snx.base_definitions())
     assert sc.identical(data[...], da)
 
 
@@ -89,7 +89,7 @@ def test_slice_of_1d(h5root):
     snx.create_field(data, 'xx', da.coords['xx'])
     snx.create_field(data, 'xx2', da.coords['xx2'])
     snx.create_field(data, 'scalar', da.coords['scalar'])
-    data = snx.Group(data, definitions=snx.base_definitions)
+    data = snx.Group(data, definitions=snx.base_definitions())
     assert sc.identical(data['xx', :2], da['xx', :2])
     assert sc.identical(data[:2], da['xx', :2])
 
@@ -107,7 +107,7 @@ def test_slice_of_multiple_coords(h5root):
     snx.create_field(data, 'xx', da.coords['xx'])
     snx.create_field(data, 'xx2', da.coords['xx2'])
     snx.create_field(data, 'yy', da.coords['yy'])
-    data = snx.Group(data, definitions=snx.base_definitions)
+    data = snx.Group(data, definitions=snx.base_definitions())
     assert sc.identical(data['xx', :2], da['xx', :2])
 
 
@@ -120,7 +120,7 @@ def test_guessed_dim_for_2d_coord_not_matching_axis_name(h5root):
     data.attrs['signal'] = 'signal'
     snx.create_field(data, 'signal', da.data)
     snx.create_field(data, 'xx2', da.coords['xx2'])
-    data = snx.Group(data, definitions=snx.base_definitions)
+    data = snx.Group(data, definitions=snx.base_definitions())
     assert sc.identical(data[...], da)
 
 
@@ -133,7 +133,7 @@ def test_skips_axis_if_dim_guessing_finds_ambiguous_shape(h5root):
     data.attrs['signal'] = 'signal'
     snx.create_field(data, 'signal', da.data)
     snx.create_field(data, 'yy2', da.coords['yy2'])
-    data = snx.Group(data, definitions=snx.base_definitions)
+    data = snx.Group(data, definitions=snx.base_definitions())
     assert set(data.dims) == {'dim_0', 'xx', 'yy'}
     dg = data[...]
     assert isinstance(dg, sc.DataGroup)
@@ -150,7 +150,7 @@ def test_guesses_transposed_dims_for_2d_coord(h5root):
     data.attrs['signal'] = 'signal'
     snx.create_field(data, 'signal', da.data)
     snx.create_field(data, 'xx2', da.coords['xx2'])
-    data = snx.Group(data, definitions=snx.base_definitions)
+    data = snx.Group(data, definitions=snx.base_definitions())
     assert sc.identical(data[...], da)
 
 
@@ -164,7 +164,7 @@ def test_indices_attribute_for_coord(h5root, indices):
     data.attrs['yy2_indices'] = indices
     snx.create_field(data, 'signal', da.data)
     snx.create_field(data, 'yy2', da.coords['yy2'])
-    data = snx.Group(data, definitions=snx.base_definitions)
+    data = snx.Group(data, definitions=snx.base_definitions())
     assert sc.identical(data[...], da)
 
 
@@ -178,7 +178,7 @@ def test_indices_attribute_for_coord_with_nontrivial_slice(h5root, indices):
     data.attrs['yy2_indices'] = indices
     snx.create_field(data, 'signal', da.data)
     snx.create_field(data, 'yy2', da.coords['yy2'])
-    data = snx.Group(data, definitions=snx.base_definitions)
+    data = snx.Group(data, definitions=snx.base_definitions())
     assert sc.identical(data['yy', :1], da['yy', :1])
 
 
@@ -191,7 +191,7 @@ def test_transpose_indices_attribute_for_coord(h5root):
     data.attrs['xx2_indices'] = [1, 0]
     snx.create_field(data, 'signal', da.data)
     snx.create_field(data, 'xx2', da.coords['xx2'])
-    data = snx.Group(data, definitions=snx.base_definitions)
+    data = snx.Group(data, definitions=snx.base_definitions())
     assert sc.identical(data[...], da)
 
 
@@ -207,7 +207,7 @@ def test_auxiliary_signal_causes_load_as_dataset(h5root):
     data.attrs['auxiliary_signals'] = ['xx']
     snx.create_field(data, 'signal', da.data)
     snx.create_field(data, 'xx', da.coords['xx'])
-    data = snx.Group(data, definitions=snx.base_definitions)
+    data = snx.Group(data, definitions=snx.base_definitions())
     assert_identical(data[...], sc.Dataset({'signal': da.data, 'xx': da.coords['xx']}))
 
 
@@ -224,7 +224,7 @@ def test_field_dims_match_NXdata_dims(h5root):
     snx.create_field(data, 'xx', da.coords['xx'])
     snx.create_field(data, 'xx2', da.coords['xx2'])
     snx.create_field(data, 'yy', da.coords['yy'])
-    data = snx.Group(data, definitions=snx.base_definitions)
+    data = snx.Group(data, definitions=snx.base_definitions())
     assert sc.identical(data['xx', :2].data, data['signal1']['xx', :2])
     assert sc.identical(data['xx', :2].coords['xx'], data['xx']['xx', :2])
     assert sc.identical(data['xx', :2].coords['xx2'], data['xx2']['xx', :2])
@@ -244,7 +244,7 @@ def test_field_dims_match_NXdata_dims_when_selected_via_class_name(h5root):
     snx.create_field(data, 'xx', da.coords['xx'])
     snx.create_field(data, 'xx2', da.coords['xx2'])
     snx.create_field(data, 'yy', da.coords['yy'])
-    data = snx.Group(data, definitions=snx.base_definitions)
+    data = snx.Group(data, definitions=snx.base_definitions())
     fields = data[snx.Field]
     assert fields['signal1'].dims == ('xx', 'yy')
     assert fields['xx'].dims == ('xx', )
@@ -261,7 +261,7 @@ def test_uses_default_field_dims_if_inference_fails(h5root):
     data.attrs['signal'] = 'signal'
     snx.create_field(data, 'signal', da.data)
     snx.create_field(data, 'yy2', da.coords['yy2'])
-    data = snx.Group(data, definitions=snx.base_definitions)
+    data = snx.Group(data, definitions=snx.base_definitions())
     dg = data[()]
     assert sc.identical(dg['yy2'], da.coords['yy2'].rename(yy='dim_0'))
     assert sc.identical(data['yy2'][()], da.coords['yy2'].rename(yy='dim_0'))
@@ -271,7 +271,7 @@ def test_uses_default_field_dims_if_inference_fails(h5root):
 def test_create_field_from_variable(h5root, unit):
     var = sc.array(dims=['xx'], unit=unit, values=[3, 4])
     snx.create_field(h5root, 'field', var)
-    group = snx.Group(h5root, definitions=snx.base_definitions)
+    group = snx.Group(h5root, definitions=snx.base_definitions())
     loaded = group['field'][...]
     # Nexus does not support storing dim labels
     assert sc.identical(loaded, var.rename(xx=loaded.dim))
@@ -281,7 +281,7 @@ def test_create_datetime_field_from_variable(h5root):
     var = sc.datetime(np.datetime64('now'), unit='ns') + sc.arange(
         'time', 1, 4, dtype='int64', unit='ns')
     snx.create_field(h5root, 'field', var)
-    group = snx.Group(h5root, definitions=snx.base_definitions)
+    group = snx.Group(h5root, definitions=snx.base_definitions())
     loaded = group['field'][...]
     # Nexus does not support storing dim labels
     assert sc.identical(loaded, var.rename(time=loaded.dim))
@@ -304,7 +304,7 @@ def test_field_matching_errors_regex_is_loaded_if_no_corresponding_value_field(
     data.attrs['signal'] = 'signal'
     snx.create_field(data, 'signal', da.data)
     snx.create_field(data, f'xx{errors_suffix}', da.coords[f'xx{errors_suffix}'])
-    data = snx.Group(data, definitions=snx.base_definitions)
+    data = snx.Group(data, definitions=snx.base_definitions())
     assert sc.identical(data[...], da)
 
 
@@ -334,7 +334,7 @@ def test_uncertainties_of_coords_are_loaded(h5root, errors_suffix):
     snx.create_field(data, f'xx2{errors_suffix}', sc.stddevs(da.coords['xx2']))
     snx.create_field(data, 'scalar', sc.values(da.coords['scalar']))
     snx.create_field(data, f'scalar{errors_suffix}', sc.stddevs(da.coords['scalar']))
-    data = snx.Group(data, definitions=snx.base_definitions)
+    data = snx.Group(data, definitions=snx.base_definitions())
     assert sc.identical(data[...], da)
 
 
@@ -346,7 +346,7 @@ def test_unnamed_extra_dims_of_coords_are_squeezed(h5root):
     data.attrs['signal'] = 'signal'
     # shape=[1]
     snx.create_field(data, 'scalar', sc.array(dims=['ignored'], values=[1.2]))
-    data = snx.Group(data, definitions=snx.base_definitions)
+    data = snx.Group(data, definitions=snx.base_definitions())
     loaded = data[...]
     assert sc.identical(loaded.coords['scalar'], sc.scalar(1.2))
     assert data['scalar'].ndim == 0
@@ -363,7 +363,7 @@ def test_unnamed_extra_dims_of_multidim_coords_are_squeezed(h5root):
     # shape=[2,1]
     xx = sc.array(dims=['xx', 'ignored'], values=[[1.1], [2.2]])
     snx.create_field(data, 'xx', xx)
-    data = snx.Group(data, definitions=snx.base_definitions)
+    data = snx.Group(data, definitions=snx.base_definitions())
     loaded = data[...]
     assert sc.identical(loaded.coords['xx'], xx['ignored', 0])
     assert data['xx'].ndim == 1
@@ -377,7 +377,7 @@ def test_dims_of_length_1_are_kept_when_axes_specified(h5root):
     snx.create_field(data, 'signal', signal)
     data.attrs['axes'] = ['xx', 'yy']
     data.attrs['signal'] = 'signal'
-    data = snx.Group(data, definitions=snx.base_definitions)
+    data = snx.Group(data, definitions=snx.base_definitions())
     loaded = data[...]
     assert sc.identical(loaded.data, signal)
     assert data['signal'].ndim == 2
@@ -389,7 +389,7 @@ def test_only_dim_of_length_1_is_squeezed_when_no_axes_specified(h5root):
     data = snx.create_class(h5root, 'data1', NXdata)
     snx.create_field(data, 'signal', signal)
     data.attrs['signal'] = 'signal'
-    data = snx.Group(data, definitions=snx.base_definitions)
+    data = snx.Group(data, definitions=snx.base_definitions())
     loaded = data[...]
     assert sc.identical(loaded.data, sc.scalar(1.1, unit='m'))
     assert data['signal'].ndim == 0
@@ -401,7 +401,7 @@ def test_multi_dims_of_length_1_are_kept_when_no_axes_specified(h5root):
     data = snx.create_class(h5root, 'data1', NXdata)
     snx.create_field(data, 'signal', signal)
     data.attrs['signal'] = 'signal'
-    data = snx.Group(data, definitions=snx.base_definitions)
+    data = snx.Group(data, definitions=snx.base_definitions())
     loaded = data[...]
     assert sc.identical(loaded.data,
                         sc.array(dims=['dim_0', 'dim_1'], unit='m', values=[[1.1]]))
@@ -414,7 +414,7 @@ def test_one_dim_of_length_1_is_kept_when_no_axes_specified(h5root):
     data = snx.create_class(h5root, 'data1', NXdata)
     snx.create_field(data, 'signal', signal)
     data.attrs['signal'] = 'signal'
-    data = snx.Group(data, definitions=snx.base_definitions)
+    data = snx.Group(data, definitions=snx.base_definitions())
     loaded = data[...]
     # Note that dimension gets renamed to `dim_0` since no axes are specified
     assert sc.identical(
@@ -430,7 +430,7 @@ def test_only_one_axis_specified_for_2d_field(h5root):
     snx.create_field(data, 'signal', signal)
     data.attrs['axes'] = ['zz']
     data.attrs['signal'] = 'signal'
-    data = snx.Group(data, definitions=snx.base_definitions)
+    data = snx.Group(data, definitions=snx.base_definitions())
     loaded = data[...]
     assert sc.identical(loaded.data, sc.array(dims=['zz'], unit='m', values=[1.1]))
 
@@ -449,7 +449,7 @@ def test_fields_with_datetime_attribute_are_loaded_as_datetime(h5root):
     snx.create_field(data, 'xx', da.coords['xx'])
     snx.create_field(data, 'xx2', da.coords['xx2'])
     snx.create_field(data, 'yy', da.coords['yy'])
-    data = snx.Group(data, definitions=snx.base_definitions)
+    data = snx.Group(data, definitions=snx.base_definitions())
     assert sc.identical(data[...], da)
 
 
@@ -465,7 +465,7 @@ def test_slicing_with_bin_edge_coord_returns_bin_edges(h5root):
     data.attrs['axes'] = ['xx']
     data.attrs['xx_indices'] = [0]
     data.attrs['xx2_indices'] = [0]
-    data = snx.Group(data, definitions=snx.base_definitions)
+    data = snx.Group(data, definitions=snx.base_definitions())
     assert sc.identical(data[...], da)
     assert sc.identical(data['xx', 0], da['xx', 0])
     assert sc.identical(data['xx', 1], da['xx', 1])
@@ -480,7 +480,7 @@ def test_legacy_signal_attr_is_used(h5root):
     data.attrs['axes'] = signal.dims
     field = snx.create_field(data, 'mysig', signal)
     field.attrs['signal'] = 1  # legacy way of defining signal
-    data = snx.Group(data, definitions=snx.base_definitions)
+    data = snx.Group(data, definitions=snx.base_definitions())
     assert sc.identical(data[...], sc.DataArray(signal))
 
 
@@ -491,7 +491,7 @@ def test_invalid_group_signal_attribute_is_ignored(h5root):
     data.attrs['signal'] = 'signal'
     field = snx.create_field(data, 'mysig', signal)
     field.attrs['signal'] = 1  # legacy way of defining signal
-    data = snx.Group(data, definitions=snx.base_definitions)
+    data = snx.Group(data, definitions=snx.base_definitions())
     assert sc.identical(data[...], sc.DataArray(signal))
 
 
@@ -506,7 +506,7 @@ def test_legacy_axis_attrs_define_dim_names(h5root):
     signal.attrs['signal'] = 1
     xx.attrs['axis'] = 1
     yy.attrs['axis'] = 2
-    data = snx.Group(data, definitions=snx.base_definitions)
+    data = snx.Group(data, definitions=snx.base_definitions())
     assert sc.identical(data[...], da)
 
 
@@ -517,7 +517,7 @@ def test_nested_groups_trigger_fallback_to_load_as_data_group(h5root):
     data.attrs['axes'] = da.dims
     data.attrs['signal'] = 'signal'
     snx.create_class(data, 'nested', NXdata)
-    data = snx.Group(data, definitions=snx.base_definitions)
+    data = snx.Group(data, definitions=snx.base_definitions())
     assert sc.identical(data[...], sc.DataGroup(signal=da.data, nested=sc.DataGroup()))
 
 
@@ -527,7 +527,7 @@ def test_slicing_raises_given_invalid_index(h5root):
     snx.create_field(data, 'signal', signal)
     data.attrs['axes'] = signal.dims
     data.attrs['signal'] = 'signal'
-    data = snx.Group(data, definitions=snx.base_definitions)
+    data = snx.Group(data, definitions=snx.base_definitions())
     assert sc.identical(data[...], sc.DataArray(signal))
     with pytest.raises(IndexError):
         data['xx', 2]

--- a/tests/nxdetector_test.py
+++ b/tests/nxdetector_test.py
@@ -9,7 +9,7 @@ from scippnexus.v2 import NXdetector, NXentry, NXoff_geometry
 
 
 def make_group(group: h5py.Group) -> snx.Group:
-    return snx.Group(group, definitions=snx.base_definitions)
+    return snx.Group(group, definitions=snx.base_definitions())
 
 
 @pytest.fixture()

--- a/tests/nxevent_data_test.py
+++ b/tests/nxevent_data_test.py
@@ -20,7 +20,7 @@ def h5root():
 def nxroot():
     """Yield NXroot containing a single NXentry named 'entry'"""
     with h5py.File('dummy.nxs', mode='w', driver="core", backing_store=False) as f:
-        root = snx.Group(f, definitions=snx.base_definitions)
+        root = snx.Group(f, definitions=snx.base_definitions())
         root.create_class('entry', snx.NXentry)
         yield root
 
@@ -110,7 +110,7 @@ def test_nxevent_data_keys(h5root):
 
 def test_nxevent_data_children_read_as_variables_with_correct_dims(h5root):
     entry = make_event_data(h5root)
-    root = snx.Group(entry, definitions=snx.base_definitions)
+    root = snx.Group(entry, definitions=snx.base_definitions())
     event_data = root['events']
     assert sc.identical(event_data['event_id'][()],
                         sc.array(dims=['event'], values=[1, 1, 1, 0], unit=None))
@@ -125,7 +125,7 @@ def test_nxevent_data_children_read_as_variables_with_correct_dims(h5root):
 
 def test_nxevent_data_dims_and_sizes_ignore_pulse_contents(h5root):
     entry = make_event_data(h5root)
-    root = snx.Group(entry, definitions=snx.base_definitions)
+    root = snx.Group(entry, definitions=snx.base_definitions())
     event_data = root['events']
     assert event_data.dims == ('event_time_zero', )
     assert event_data.sizes == {'event_time_zero': 2}
@@ -133,7 +133,7 @@ def test_nxevent_data_dims_and_sizes_ignore_pulse_contents(h5root):
 
 def test_read_nxevent_data(h5root):
     entry = make_event_data(h5root)
-    root = snx.Group(entry, definitions=snx.base_definitions)
+    root = snx.Group(entry, definitions=snx.base_definitions())
     event_data = root['events']
     da = event_data[()]
     assert sc.identical(da.data.bins.size(),

--- a/tests/nxmonitor_test.py
+++ b/tests/nxmonitor_test.py
@@ -14,14 +14,14 @@ def h5root():
 
 
 def make_group(group: h5py.Group) -> snx.Group:
-    return snx.Group(group, definitions=snx.base_definitions)
+    return snx.Group(group, definitions=snx.base_definitions())
 
 
 @pytest.fixture()
 def group():
     """Yield NXroot containing a single NXentry named 'entry'"""
     with h5py.File('dummy.nxs', mode='w', driver="core", backing_store=False) as f:
-        yield snx.Group(f, definitions=snx.base_definitions)
+        yield snx.Group(f, definitions=snx.base_definitions())
 
 
 def test_dense_monitor(h5root):

--- a/tests/nxoff_geometry_test.py
+++ b/tests/nxoff_geometry_test.py
@@ -11,7 +11,7 @@ from scippnexus.v2.nxoff_geometry import NXoff_geometry, off_to_shape
 def group():
     """Yield NXroot containing a single NXentry named 'entry'"""
     with h5py.File('dummy.nxs', mode='w', driver="core", backing_store=False) as f:
-        yield snx.Group(f, definitions=snx.base_definitions)
+        yield snx.Group(f, definitions=snx.base_definitions())
 
 
 def test_vertices_loaded_as_vector3(group):

--- a/tests/nxsample_test.py
+++ b/tests/nxsample_test.py
@@ -12,7 +12,7 @@ import scippnexus.v2 as snx
 def nxroot():
     """Yield NXroot containing a single NXentry named 'entry'"""
     with h5py.File('dummy.nxs', mode='w', driver="core", backing_store=False) as f:
-        root = snx.Group(f, definitions=snx.base_definitions)
+        root = snx.Group(f, definitions=snx.base_definitions())
         root.create_class('entry', snx.NXentry)
         yield root
 

--- a/tests/nxtransformations_test.py
+++ b/tests/nxtransformations_test.py
@@ -9,7 +9,7 @@ from scippnexus.v2.nxtransformations import NXtransformations
 
 
 def make_group(group: h5py.Group) -> snx.Group:
-    return snx.Group(group, definitions=snx.base_definitions)
+    return snx.Group(group, definitions=snx.base_definitions())
 
 
 @pytest.fixture()


### PR DESCRIPTION
Major changes:

- The application-definition mechanism works differently now.
- We have currently removed the nx-class based properties allowing for access like `f.entry.instrument`.