### PR TITLE
Fix issue with dims setup for NXdetector with event data

### DIFF
--- a/src/scippnexus/v2/base.py
+++ b/src/scippnexus/v2/base.py
@@ -66,7 +66,8 @@ def _squeezed_field_sizes(dataset: H5Dataset) -> Dict[str, int]:
 class NXobject:
 
     def _init_field(self, field: Field):
-        field.sizes = _squeezed_field_sizes(field.dataset)
+        if field.sizes is None:
+            field.sizes = _squeezed_field_sizes(field.dataset)
         field.dtype = _dtype_fromdataset(field.dataset)
 
     def __init__(self, attrs: Dict[str, Any], children: Dict[str, Union[Field, Group]]):

--- a/src/scippnexus/v2/nxdata.py
+++ b/src/scippnexus/v2/nxdata.py
@@ -287,7 +287,7 @@ class NXdata(NXobject):
                  dg: sc.DataGroup) -> Union[sc.DataGroup, sc.DataArray, sc.Dataset]:
         if not self._valid:
             raise NexusStructureError("Could not determine signal field or dimensions.")
-        dg = dg.copy()
+        dg = dg.copy(deep=False)
         aux = {name: dg.pop(name) for name in self._aux_signals}
         signal = dg.pop(self._signal_name)
         coords = dg
@@ -511,7 +511,7 @@ def _find_event_entries(dg: sc.DataGroup) -> List[str]:
 
 def group_events_by_detector_number(
         dg: sc.DataGroup) -> Union[sc.DataArray, sc.Dataset]:
-    dg = dg.copy()
+    dg = dg.copy(deep=False)
     grouping_key = None
     for key in NXdetector._detector_number_fields:
         if (grouping := dg.get(key)) is not None:

--- a/src/scippnexus/v2/nxdata.py
+++ b/src/scippnexus/v2/nxdata.py
@@ -71,32 +71,35 @@ class NXdata(NXobject):
         self._init_group_dims(attrs=attrs, fallback_dims=fallback_dims)
 
         for name, field in children.items():
-            if not isinstance(field, Field):
-                # If the NXdata contains subgroups we can generally not define valid
-                # sizes... except for some non-signal "special fields" that return
-                # a DataGroup that will be wrapped in a scalar Variable.
-                if name == self._signal_name or name in self._aux_signals:
-                    continue
-                if field.attrs.get('NX_class') not in [
-                        'NXoff_geometry',
-                        'NXcylindrical_geometry',
-                        'NXgeometry',
-                        'NXtransformations',
-                ]:
-                    self._valid = False
-            elif (dims := self._get_dims(name, field)) is not None:
-                # The convention here is that the given dimensions apply to the shapes
-                # starting from the left. So we only squeeze dimensions that are after
-                # len(dims).
-                shape = _squeeze_trailing(dims, field.dataset.shape)
-                field.sizes = dict(zip(dims, shape))
-            elif self._valid:
-                s1 = self._signal.sizes
-                s2 = field.sizes
-                if not set(s2.keys()).issubset(set(s1.keys())):
-                    self._valid = False
-                elif any(s1[k] != s2[k] for k in s1.keys() & s2.keys()):
-                    self._valid = False
+            self._init_field_dims(name, field)
+
+    def _init_field_dims(self, name: str, field: Union[Field, Group]) -> None:
+        if not isinstance(field, Field):
+            # If the NXdata contains subgroups we can generally not define valid
+            # sizes... except for some non-signal "special fields" that return
+            # a DataGroup that will be wrapped in a scalar Variable.
+            if name == self._signal_name or name in self._aux_signals:
+                return
+            if field.attrs.get('NX_class') not in [
+                    'NXoff_geometry',
+                    'NXcylindrical_geometry',
+                    'NXgeometry',
+                    'NXtransformations',
+            ]:
+                self._valid = False
+        elif (dims := self._get_dims(name, field)) is not None:
+            # The convention here is that the given dimensions apply to the shapes
+            # starting from the left. So we only squeeze dimensions that are after
+            # len(dims).
+            shape = _squeeze_trailing(dims, field.dataset.shape)
+            field.sizes = dict(zip(dims, shape))
+        elif self._valid:
+            s1 = self._signal.sizes
+            s2 = field.sizes
+            if not set(s2.keys()).issubset(set(s1.keys())):
+                self._valid = False
+            elif any(s1[k] != s2[k] for k in s1.keys() & s2.keys()):
+                self._valid = False
 
     def _init_signal(self, name: Optional[str], children):
         # There are multiple ways NeXus can define the "signal" dataset. The latest
@@ -246,7 +249,8 @@ class NXdata(NXobject):
             return (name, )
         if self._signal is not None and self._group_dims is not None:
             signal_shape = self._signal.dataset.shape if isinstance(
-                self._signal, Field) else None
+                self._signal, Field) else (self._signal.shape if isinstance(
+                    self._signal, EventField) else None)
             return _guess_dims(self._group_dims, signal_shape, field.dataset)
 
     @cached_property
@@ -400,6 +404,10 @@ class EventField:
     @property
     def dims(self) -> Tuple[str, ...]:
         return self._grouping.dims + self._event_data.dims
+
+    @property
+    def shape(self) -> Tuple[int, ...]:
+        return self._grouping.shape + self._event_data.shape
 
     def __getitem__(self, sel: ScippIndex) -> sc.DataArray:
         event_sel = to_child_select(self.dims, self._event_data.dims, sel)

--- a/tests/externalfile.py
+++ b/tests/externalfile.py
@@ -20,6 +20,7 @@ def _make_pooch():
             'md5:f431d9775a53caffeebe9b879189b17c',
             '2023/NMX_2e11-rechunk.h5': 'md5:1174c208614b2e7a5faddc284b41d2c9',
             '2023/YMIR_038243_00010244.hdf': 'md5:cefb04b6d4d36f16e7f329a6045ad129',
+            '2023/amor2020n000346_tweaked.nxs': 'md5:4e07ccc87b5c6549e190bc372c298e83',
         })
 
 

--- a/tests/externalfile.py
+++ b/tests/externalfile.py
@@ -13,14 +13,22 @@ def _make_pooch():
         retry_if_failed=3,
         base_url='login.esss.dk:/mnt/groupdata/scipp/testdata/scippnexus/',
         registry={
-            '2023/DREAM_baseline_all_dets.nxs': 'md5:1e1a3141c6785d25777b456e2a653f42',
-            '2023/BIFROST_873855_00000015.hdf': 'md5:eb180b09d265c308e81c4a4885662bbd',
-            '2023/DREAM_mccode.h5': 'md5:ebe4be53f20e139e865bc20b264bdceb',
+            '2023/DREAM_baseline_all_dets.nxs':
+            'md5:1e1a3141c6785d25777b456e2a653f42',
+            '2023/BIFROST_873855_00000015.hdf':
+            'md5:eb180b09d265c308e81c4a4885662bbd',
+            '2023/DREAM_mccode.h5':
+            'md5:ebe4be53f20e139e865bc20b264bdceb',
             '2023/LOKI_mcstas_nexus_geometry.nxs':
             'md5:f431d9775a53caffeebe9b879189b17c',
-            '2023/NMX_2e11-rechunk.h5': 'md5:1174c208614b2e7a5faddc284b41d2c9',
-            '2023/YMIR_038243_00010244.hdf': 'md5:cefb04b6d4d36f16e7f329a6045ad129',
-            '2023/amor2020n000346_tweaked.nxs': 'md5:4e07ccc87b5c6549e190bc372c298e83',
+            '2023/NMX_2e11-rechunk.h5':
+            'md5:1174c208614b2e7a5faddc284b41d2c9',
+            '2023/YMIR_038243_00010244.hdf':
+            'md5:cefb04b6d4d36f16e7f329a6045ad129',
+            '2023/amor2020n000346_tweaked.nxs':
+            'md5:4e07ccc87b5c6549e190bc372c298e83',
+            '2023/LOKI_60322-2022-03-02_2205_fixed.nxs':
+            'md5:e174d87dff10cbdcc2a33d093ae1e8ce',
         })
 
 

--- a/tests/load_files_test.py
+++ b/tests/load_files_test.py
@@ -17,6 +17,7 @@ all_files = [
     '2023/NMX_2e11-rechunk.h5',
     '2023/YMIR_038243_00010244.hdf',
     '2023/amor2020n000346_tweaked.nxs',
+    '2023/LOKI_60322-2022-03-02_2205_fixed.nxs',
 ]
 
 
@@ -82,4 +83,22 @@ def test_amor2020n000346_tweaked():
         sc.DataArray, {'detector_number': 9216})
     schema['entry/stages/com'] = validator(sc.DataArray, {'time': 1, 'dim_1': 1})
     schema['entry/facility'] = validator(str)
+    assert_schema(dg, schema)
+
+
+@pytest.mark.externalfile
+def test_LOKI_60322_2022_03_02_2205_fixed():
+    with snx.File(
+            externalfile.get_path('2023/LOKI_60322-2022-03-02_2205_fixed.nxs')) as f:
+        dg = f[()]
+    schema = {}
+    schema['entry/instrument/larmor_detector'] = bins_validator(
+        sc.DataArray, {'detector_number': 458752})
+    schema['entry/instrument/monitor_1'] = bins_validator(sc.DataArray,
+                                                          {'event_time_zero': 1987})
+    schema['entry/instrument/monitor_2'] = bins_validator(sc.DataArray,
+                                                          {'event_time_zero': 1987})
+    schema['entry/instrument/source/transformations/trans_2'] = validator(
+        sc.DataArray, {}, sc.DType.translation3)
+
     assert_schema(dg, schema)

--- a/tests/load_files_test.py
+++ b/tests/load_files_test.py
@@ -1,5 +1,7 @@
 # SPDX-License-Identifier: BSD-3-Clause
 # Copyright (c) 2023 Scipp contributors (https://github.com/scipp)
+from typing import Any, Dict, Optional, Union
+
 import pytest
 import scipp as sc
 
@@ -14,7 +16,45 @@ all_files = [
     '2023/LOKI_mcstas_nexus_geometry.nxs',
     '2023/NMX_2e11-rechunk.h5',
     '2023/YMIR_038243_00010244.hdf',
+    '2023/amor2020n000346_tweaked.nxs',
 ]
+
+
+def get_item_at_path(dg: sc.DataGroup, path: str) -> sc.DataArray:
+    nodes = path.split('/')
+    for node in nodes:
+        dg = dg[node]
+    return dg
+
+
+def assert_schema(dg: sc.DataGroup, schema: Dict[str, Any]) -> None:
+    for name, validate in schema.items():
+        validate(get_item_at_path(dg, name))
+
+
+def validator(item_type: type,
+              sizes: Optional[Dict[str, int]] = None,
+              dtype: Optional[Union[str, sc.DType]] = None) -> None:
+
+    def _validator(item):
+        assert isinstance(item, item_type)
+        if sizes is not None:
+            assert item.sizes == sizes
+        if dtype is not None:
+            assert item.dtype == dtype
+
+    return _validator
+
+
+def bins_validator(item_type: type, sizes: Optional[Dict[str, int]] = None):
+
+    def _validator(item):
+        assert isinstance(item, item_type)
+        assert item.bins is not None
+        if sizes is not None:
+            assert item.sizes == sizes
+
+    return _validator
 
 
 @pytest.mark.externalfile
@@ -31,3 +71,15 @@ def test_files_load_as_data_groups_with_no_definitions(name):
     with snx.File(externalfile.get_path(name), definitions={}) as f:
         dg = f[()]
     assert isinstance(dg, sc.DataGroup)
+
+
+@pytest.mark.externalfile
+def test_amor2020n000346_tweaked():
+    with snx.File(externalfile.get_path('2023/amor2020n000346_tweaked.nxs')) as f:
+        dg = f[()]
+    schema = {}
+    schema['entry/instrument/multiblade_detector'] = bins_validator(
+        sc.DataArray, {'detector_number': 9216})
+    schema['entry/stages/com'] = validator(sc.DataArray, {'time': 1, 'dim_1': 1})
+    schema['entry/facility'] = validator(str)
+    assert_schema(dg, schema)

--- a/tests/nxdetector_test.py
+++ b/tests/nxdetector_test.py
@@ -196,6 +196,19 @@ def test_loads_event_data_mapped_to_detector_numbers_based_on_their_event_id(nxr
     assert 'event_time_zero' in da.bins.coords
 
 
+def test_detector_number_fallback_dims_determines_dims_with_event_data(nxroot):
+    detector_numbers = sc.array(dims=['detector_number'],
+                                unit=None,
+                                values=np.array([1, 2, 3, 4, 5, 6]))
+    detector = nxroot.create_class('detector0', NXdetector)
+    detector.create_field('detector_number', detector_numbers)
+    detector.create_field('pixel_offset', detector_numbers)
+    create_event_data_ids_1234(detector.create_class('events', snx.NXevent_data))
+    da = detector[()]
+    assert da.sizes == {'detector_number': 6}
+    assert_identical(da.coords['pixel_offset'], detector_numbers)
+
+
 def test_loads_event_data_with_0d_detector_numbers(nxroot):
     detector = nxroot.create_class('detector0', NXdetector)
     detector.create_field('detector_number', sc.index(1, dtype='int64'))


### PR DESCRIPTION
NXdetector initialized the dims of the detector_number field, but NXdata subsequently called NXobject.__init__, which overrode this.

Furthermore, the dim guessing logic ignored event-signals.

After this, the AMOR file now correctly loads the NXdetector as a DataArray.