### PR TITLE
Load NXdetector and NXmonitor as DataGroup

### DIFF
--- a/docs/user-guide/nexus-classes.ipynb
+++ b/docs/user-guide/nexus-classes.ipynb
@@ -107,7 +107,7 @@
     "\n",
     "Provides multi-dimensional labeled data.\n",
     "See the NeXus format [NXdata base class definition](https://manual.nexusformat.org/classes/base_classes/NXdata.html) for details.\n",
-    "Can be read as a data array using slicing syntax.\n",
+    "Can be read as a data array using positional indexing.\n",
     "\n",
     "Example:"
    ]
@@ -145,7 +145,7 @@
     "Provides data for a detector.\n",
     "See the NeXus format [NXdetector base class definition](https://manual.nexusformat.org/classes/base_classes/NXdetector.html) for details.\n",
     "`NXdetector` contains data and coords similar to `NXdata` as well as additional fields that are not readily inserted into a `scipp.DataArray`.\n",
-    "Therefore, `NXdetector` can be read as a `scipp.DataGroup` wrapping a `scipp.DataArray` using slicing syntax.\n",
+    "Therefore, `NXdetector` can be read as a `scipp.DataGroup` wrapping a `scipp.DataArray` using positional indexing.\n",
     "The \"signal\" field and associated coordinates are combined into a `scipp.DataArray` and the remaining fields are added as fields to the `scipp.DataGroup`.\n",
     "In the output, the `scipp.DataArray` has the same name as the \"signal\" dataset in the NeXus file.\n",
     "The underlying data may be dense data or event data.\n",
@@ -295,7 +295,7 @@
     "\n",
     "Provides a  time-series log.\n",
     "See the NeXus format [NXlog base class definition](https://manual.nexusformat.org/classes/base_classes/NXlog.html) for details.\n",
-    "Can be read as a data array using slicing syntax.\n",
+    "Can be read as a data array using positional indexing.\n",
     "\n",
     "Example:"
    ]
@@ -332,7 +332,7 @@
     "\n",
     "Provides data for a beam monitor.\n",
     "See the NeXus format [NXmonitor base class definition](https://manual.nexusformat.org/classes/base_classes/NXmonitor.html) for details.\n",
-    "Can be read as a `scipp.DataGroup` holding a `scipp.DataArray` using slicing syntax, similar to `NXdetector`.\n",
+    "Can be read as a `scipp.DataGroup` holding a `scipp.DataArray` using positional indexing, similar to `NXdetector`.\n",
     "\n",
     "Example:"
    ]

--- a/docs/user-guide/nexus-classes.ipynb
+++ b/docs/user-guide/nexus-classes.ipynb
@@ -28,13 +28,13 @@
     "NeXus class | read as | comment | NeXus specification\n",
     ":--- |:--- |:--- |:---\n",
     "[NXdata](../generated/classes/scippnexus.NXdata.rst) | scipp.DataArray | [example below](#NXdata) | [link](https://manual.nexusformat.org/classes/base_classes/NXdata.html)\n",
-    "[NXdetector](../generated/classes/scippnexus.NXdetector.rst) | scipp.DataArray | [example below](#NXdetector) | [link](https://manual.nexusformat.org/classes/base_classes/NXdetector.html)\n",
+    "[NXdetector](../generated/classes/scippnexus.NXdetector.rst) | scipp.DataGroup wrapping scipp.DataArray | [example below](#NXdetector) | [link](https://manual.nexusformat.org/classes/base_classes/NXdetector.html)\n",
     "[NXdisk_chopper](../generated/classes/scippnexus.NXdisk_chopper.rst) | scipp.DataGroup || [link](https://manual.nexusformat.org/classes/base_classes/NXdisk_chopper.html)\n",
     "[NXentry](../generated/classes/scippnexus.NXentry.rst) | scipp.DataGroup | [generic group-like](#Base-class:-NXobject) | [link](https://manual.nexusformat.org/classes/base_classes/NXentry.html)\n",
     "[NXevent_data](../generated/classes/scippnexus.NXevent_data.rst) | scipp.DataArray | [example below](#NXevent_data) | [link](https://manual.nexusformat.org/classes/base_classes/NXevent_data.html)\n",
     "[NXinstrument](../generated/classes/scippnexus.NXinstrument.rst) | scipp.DataGroup | [generic group-like](#Base-class:-NXobject) | [link](https://manual.nexusformat.org/classes/base_classes/NXinstrument.html)\n",
     "[NXlog](../generated/classes/scippnexus.NXlog.rst) | scipp.DataArray | [example below](#NXlog) | [link](https://manual.nexusformat.org/classes/base_classes/NXlog.html)\n",
-    "[NXmonitor](../generated/classes/scippnexus.NXmonitor.rst) | scipp.DataArray | [example below](#NXmonitor) | [link](https://manual.nexusformat.org/classes/base_classes/NXmonitor.html)\n",
+    "[NXmonitor](../generated/classes/scippnexus.NXmonitor.rst) | scipp.DataGroup wrapping scipp.DataArray | [example below](#NXmonitor) | [link](https://manual.nexusformat.org/classes/base_classes/NXmonitor.html)\n",
     "[NXroot](../generated/classes/scippnexus.NXroot.rst) | scipp.DataGroup | [generic group-like](#Base-class:-NXobject) | [link](https://manual.nexusformat.org/classes/base_classes/NXroot.html)\n",
     "[NXsample](../generated/classes/scippnexus.NXsample.rst) | scipp.DataGroup || [link](https://manual.nexusformat.org/classes/base_classes/NXsample.html)\n",
     "[NXsource](../generated/classes/scippnexus.NXsource.rst) | scipp.DataGroup || [link](https://manual.nexusformat.org/classes/base_classes/NXsource.html)\n",
@@ -61,8 +61,10 @@
    "outputs": [],
    "source": [
     "from scippnexus import data\n",
+    "\n",
     "filename = data.get_path('PG3_4844_event.nxs')\n",
     "import scippnexus as snx\n",
+    "\n",
     "f = snx.File(filename)"
    ]
   },
@@ -142,7 +144,10 @@
     "\n",
     "Provides data for a detector.\n",
     "See the NeXus format [NXdetector base class definition](https://manual.nexusformat.org/classes/base_classes/NXdetector.html) for details.\n",
-    "Can be read as a data array using slicing syntax.\n",
+    "`NXdetector` contains data and coords similar to `NXdata` as well as additional fields that are not readily inserted into a `scipp.DataArray`.\n",
+    "Therefore, `NXdetector` can be read as a `scipp.DataGroup` wrapping a `scipp.DataArray` using slicing syntax.\n",
+    "The \"signal\" field and associated coordinates are combined into a `scipp.DataArray` and the remaining fields are added as fields to the `scipp.DataGroup`.\n",
+    "In the output, the `scipp.DataArray` has the same name as the \"signal\" dataset in the NeXus file.\n",
     "The underlying data may be dense data or event data.\n",
     "\n",
     "Example:"
@@ -166,7 +171,36 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "detector[...]"
+    "det = detector[...]\n",
+    "det"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c6dd1966",
+   "metadata": {},
+   "source": [
+    "In this example both dense data (\"data_x\") and event data (\"events\") are present:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "036e26bc",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "det['data_x_y']"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "2e74ef95",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "det['events']"
    ]
   },
   {
@@ -298,7 +332,7 @@
     "\n",
     "Provides data for a beam monitor.\n",
     "See the NeXus format [NXmonitor base class definition](https://manual.nexusformat.org/classes/base_classes/NXmonitor.html) for details.\n",
-    "Can be read as a data array using slicing syntax.\n",
+    "Can be read as a `scipp.DataGroup` holding a `scipp.DataArray` using slicing syntax, similar to `NXdetector`.\n",
     "\n",
     "Example:"
    ]
@@ -311,7 +345,18 @@
    "outputs": [],
    "source": [
     "monitor = f['entry/monitor1']\n",
-    "monitor[...]"
+    "mon = monitor[...]\n",
+    "mon"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "e9f093cd",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "mon['data']"
    ]
   }
  ],

--- a/src/scippnexus/nxdata.py
+++ b/src/scippnexus/nxdata.py
@@ -413,12 +413,15 @@ class NXdata(NXobject):
         Sets alignment in the same way as slicing scipp.DataArray would.
         """
         for name, coord in coords.items():
-            da.coords[name] = coord
-            # We need the shape *before* slicing to determine dims, so we get the
-            # field from the group for the conditional.
-            da.coords.set_aligned(
-                name, self._should_be_aligned(da, name, self._children[name])
-            )
+            if not isinstance(coord, sc.Variable):
+                da.coords[name] = sc.scalar(coord)
+            else:
+                da.coords[name] = coord
+                # We need the shape *before* slicing to determine dims, so we get the
+                # field from the group for the conditional.
+                da.coords.set_aligned(
+                    name, self._should_be_aligned(da, name, self._children[name])
+                )
         return da
 
 

--- a/src/scippnexus/nxdata.py
+++ b/src/scippnexus/nxdata.py
@@ -413,15 +413,12 @@ class NXdata(NXobject):
         Sets alignment in the same way as slicing scipp.DataArray would.
         """
         for name, coord in coords.items():
-            if not isinstance(coord, sc.Variable):
-                da.coords[name] = sc.scalar(coord)
-            else:
-                da.coords[name] = coord
-                # We need the shape *before* slicing to determine dims, so we get the
-                # field from the group for the conditional.
-                da.coords.set_aligned(
-                    name, self._should_be_aligned(da, name, self._children[name])
-                )
+            da.coords[name] = coord
+            # We need the shape *before* slicing to determine dims, so we get the
+            # field from the group for the conditional.
+            da.coords.set_aligned(
+                name, self._should_be_aligned(da, name, self._children[name])
+            )
         return da
 
 

--- a/tests/nxdetector_test.py
+++ b/tests/nxdetector_test.py
@@ -47,9 +47,9 @@ def test_finds_data_from_group_attr(h5root):
     da = sc.DataArray(
         sc.array(dims=['xx', 'yy'], unit='K', values=[[1.1, 2.2], [3.3, 4.4]])
     )
-    da.coords['detector_numbers'] = detector_numbers_xx_yy_1234()
+    da.coords['detector_number'] = detector_numbers_xx_yy_1234()
     detector = snx.create_class(h5root, 'detector0', NXdetector)
-    snx.create_field(detector, 'detector_numbers', da.coords['detector_numbers'])
+    snx.create_field(detector, 'detector_number', da.coords['detector_number'])
     snx.create_field(detector, 'custom', da.data)
     detector.attrs['signal'] = 'custom'
     detector = make_group(detector)
@@ -105,9 +105,9 @@ def detector_numbers_xx_yy_1234():
 
 def test_loads_data_without_coords(h5root):
     da = sc.DataArray(sc.array(dims=['xx', 'yy'], values=[[1.1, 2.2], [3.3, 4.4]]))
-    da.coords['detector_numbers'] = detector_numbers_xx_yy_1234()
+    da.coords['detector_number'] = detector_numbers_xx_yy_1234()
     detector = snx.create_class(h5root, 'detector0', NXdetector)
-    snx.create_field(detector, 'detector_numbers', da.coords['detector_numbers'])
+    snx.create_field(detector, 'detector_number', da.coords['detector_number'])
     snx.create_field(detector, 'data', da.data)
     detector = make_group(detector)
     assert sc.identical(
@@ -134,10 +134,10 @@ def test_loads_data_with_coords(h5root):
     da = sc.DataArray(
         sc.array(dims=['xx', 'yy'], unit='K', values=[[1.1, 2.2], [3.3, 4.4]])
     )
-    da.coords['detector_numbers'] = detector_numbers_xx_yy_1234()
+    da.coords['detector_number'] = detector_numbers_xx_yy_1234()
     da.coords['xx'] = sc.array(dims=['xx'], unit='m', values=[0.1, 0.2])
     detector = snx.create_class(h5root, 'detector0', NXdetector)
-    snx.create_field(detector, 'detector_numbers', da.coords['detector_numbers'])
+    snx.create_field(detector, 'detector_number', da.coords['detector_number'])
     snx.create_field(detector, 'xx', da.coords['xx'])
     snx.create_field(detector, 'data', da.data)
     detector.attrs['axes'] = ['xx', '.']
@@ -149,7 +149,7 @@ def test_slicing_works_as_in_scipp(h5root):
     da = sc.DataArray(
         sc.array(dims=['xx', 'yy'], unit='K', values=[[1.1, 2.2, 3.3], [3.3, 4.4, 5.5]])
     )
-    da.coords['detector_numbers'] = sc.array(
+    da.coords['detector_number'] = sc.array(
         dims=['xx', 'yy'], unit=None, values=np.array([[1, 2, 3], [4, 5, 6]])
     )
     da.coords['xx'] = sc.array(dims=['xx'], unit='m', values=[0.1, 0.2])
@@ -159,13 +159,14 @@ def test_slicing_works_as_in_scipp(h5root):
         dims=['yy', 'xx'], unit='m', values=[[1, 2, 3], [4, 5, 6], [7, 8, 9]]
     )
     detector = snx.create_class(h5root, 'detector0', NXdetector)
-    snx.create_field(detector, 'detector_numbers', da.coords['detector_numbers'])
+    snx.create_field(detector, 'detector_number', da.coords['detector_number'])
     snx.create_field(detector, 'xx', da.coords['xx'])
     snx.create_field(detector, 'xx2', da.coords['xx2'])
     snx.create_field(detector, 'yy', da.coords['yy'])
     snx.create_field(detector, '2d_edges', da.coords['2d_edges'])
     snx.create_field(detector, 'data', da.data)
     detector.attrs['axes'] = ['xx', 'yy']
+    detector.attrs['xx2_indices'] = [0]
     detector.attrs['2d_edges_indices'] = [1, 0]
     detector = make_group(detector)
     assert_identical(detector[...]['data'], da)
@@ -222,11 +223,9 @@ def test_detector_number_fallback_dims_determines_dims_with_event_data(nxroot):
     )
     detector = nxroot.create_class('detector0', NXdetector)
     detector.create_field('detector_number', detector_numbers)
-    detector.create_field('pixel_offset', detector_numbers)
     create_event_data_ids_1234(detector.create_class('events', snx.NXevent_data))
     da = detector[()]['events']
     assert da.sizes == {'detector_number': 6}
-    assert_identical(da.coords['pixel_offset'], detector_numbers)
 
 
 def test_loads_event_data_with_0d_detector_numbers(nxroot):

--- a/tests/nxdetector_test.py
+++ b/tests/nxdetector_test.py
@@ -53,7 +53,10 @@ def test_finds_data_from_group_attr(h5root):
     snx.create_field(detector, 'custom', da.data)
     detector.attrs['signal'] = 'custom'
     detector = make_group(detector)
-    assert sc.identical(detector[...], da.rename_dims({'xx': 'dim_0', 'yy': 'dim_1'}))
+    loaded = detector[...]
+    assert sc.identical(
+        loaded['custom'], da.rename_dims({'xx': 'dim_0', 'yy': 'dim_1'})
+    )
 
 
 def test_loads_signal_and_events_when_both_found(nxroot):
@@ -69,7 +72,7 @@ def test_loads_signal_and_events_when_both_found(nxroot):
     events.create_field('event_index', sc.array(dims=[''], unit='None', values=[0]))
     assert detector.sizes == {'detector_number': 2, 'event_time_zero': 1}
     loaded = detector[...]
-    assert isinstance(loaded, sc.Dataset)
+    assert isinstance(loaded, sc.DataGroup)
     assert_identical(loaded['data'].data, data)
     assert loaded['events'].bins is not None
 
@@ -85,7 +88,7 @@ def test_loads_as_data_array_with_embedded_events(nxroot):
     detector.create_field('event_time_zero', sc.array(dims=[''], unit='s', values=[1]))
     detector.create_field('event_index', sc.array(dims=[''], unit='None', values=[0]))
     assert detector.dims == ('detector_number', 'event_time_zero')
-    da = detector[...]
+    da = detector[...]['events']
     assert da.bins is not None
     assert_identical(
         da.bins.size(),
@@ -107,7 +110,9 @@ def test_loads_data_without_coords(h5root):
     snx.create_field(detector, 'detector_numbers', da.coords['detector_numbers'])
     snx.create_field(detector, 'data', da.data)
     detector = make_group(detector)
-    assert sc.identical(detector[...], da.rename_dims({'xx': 'dim_0', 'yy': 'dim_1'}))
+    assert sc.identical(
+        detector[...]['data'], da.rename_dims({'xx': 'dim_0', 'yy': 'dim_1'})
+    )
 
 
 @pytest.mark.parametrize(
@@ -120,7 +125,9 @@ def test_detector_number_key_alias(h5root, detector_number_key):
     snx.create_field(detector, detector_number_key, da.coords[detector_number_key])
     snx.create_field(detector, 'data', da.data)
     detector = make_group(detector)
-    assert sc.identical(detector[...], da.rename_dims({'xx': 'dim_0', 'yy': 'dim_1'}))
+    assert sc.identical(
+        detector[...]['data'], da.rename_dims({'xx': 'dim_0', 'yy': 'dim_1'})
+    )
 
 
 def test_loads_data_with_coords(h5root):
@@ -135,7 +142,7 @@ def test_loads_data_with_coords(h5root):
     snx.create_field(detector, 'data', da.data)
     detector.attrs['axes'] = ['xx', '.']
     detector = make_group(detector)
-    assert sc.identical(detector[...], da.rename_dims({'yy': 'dim_1'}))
+    assert sc.identical(detector[...]['data'], da.rename_dims({'yy': 'dim_1'}))
 
 
 def test_slicing_works_as_in_scipp(h5root):
@@ -161,14 +168,14 @@ def test_slicing_works_as_in_scipp(h5root):
     detector.attrs['axes'] = ['xx', 'yy']
     detector.attrs['2d_edges_indices'] = [1, 0]
     detector = make_group(detector)
-    assert_identical(detector[...], da)
-    assert_identical(detector['xx', 0], da['xx', 0])
-    assert_identical(detector['xx', 1], da['xx', 1])
-    assert_identical(detector['xx', 0:1], da['xx', 0:1])
-    assert_identical(detector['yy', 0], da['yy', 0])
-    assert_identical(detector['yy', 1], da['yy', 1])
-    assert_identical(detector['yy', 0:1], da['yy', 0:1])
-    assert_identical(detector['yy', 1:1], da['yy', 1:1])  # empty slice
+    assert_identical(detector[...]['data'], da)
+    assert_identical(detector['xx', 0]['data'], da['xx', 0])
+    assert_identical(detector['xx', 1]['data'], da['xx', 1])
+    assert_identical(detector['xx', 0:1]['data'], da['xx', 0:1])
+    assert_identical(detector['yy', 0]['data'], da['yy', 0])
+    assert_identical(detector['yy', 1]['data'], da['yy', 1])
+    assert_identical(detector['yy', 0:1]['data'], da['yy', 0:1])
+    assert_identical(detector['yy', 1:1]['data'], da['yy', 1:1])  # empty slice
 
 
 def create_event_data_ids_1234(group):
@@ -195,7 +202,7 @@ def test_loads_event_data_mapped_to_detector_numbers_based_on_their_event_id(nxr
     detector.create_field('detector_number', detector_numbers)
     create_event_data_ids_1234(detector.create_class('events', snx.NXevent_data))
     assert detector.sizes == {'detector_number': 6, 'event_time_zero': 4}
-    da = detector[...]
+    da = detector[...]['events']
     assert sc.identical(
         da.bins.size().data,
         sc.array(
@@ -217,7 +224,7 @@ def test_detector_number_fallback_dims_determines_dims_with_event_data(nxroot):
     detector.create_field('detector_number', detector_numbers)
     detector.create_field('pixel_offset', detector_numbers)
     create_event_data_ids_1234(detector.create_class('events', snx.NXevent_data))
-    da = detector[()]
+    da = detector[()]['events']
     assert da.sizes == {'detector_number': 6}
     assert_identical(da.coords['pixel_offset'], detector_numbers)
 
@@ -228,7 +235,7 @@ def test_loads_event_data_with_0d_detector_numbers(nxroot):
     create_event_data_ids_1234(detector.create_class('events', snx.NXevent_data))
     assert detector.dims == ('event_time_zero',)
     assert detector.shape == (4,)
-    da = detector[...]
+    da = detector[...]['events']
     assert sc.identical(da.bins.size().data, sc.index(2, dtype='int64'))
 
 
@@ -237,7 +244,7 @@ def test_loads_event_data_with_2d_detector_numbers(nxroot):
     detector.create_field('detector_number', detector_numbers_xx_yy_1234())
     create_event_data_ids_1234(detector.create_class('events', snx.NXevent_data))
     assert detector.sizes == {'dim_0': 2, 'dim_1': 2, 'event_time_zero': 4}
-    da = detector[...]
+    da = detector[...]['events']
     assert sc.identical(
         da.bins.size().data,
         sc.array(
@@ -251,7 +258,7 @@ def test_selecting_pixels_works_with_event_signal(nxroot):
     detector.create_field('detector_number', detector_numbers_xx_yy_1234())
     create_event_data_ids_1234(detector.create_class('events', snx.NXevent_data))
     assert detector.sizes == {'dim_0': 2, 'dim_1': 2, 'event_time_zero': 4}
-    da = detector['dim_0', 0]
+    da = detector['dim_0', 0]['events']
     assert_identical(
         da.bins.size().data,
         sc.array(dims=['dim_1'], unit=None, dtype='int64', values=[2, 3]),
@@ -263,7 +270,7 @@ def test_selecting_pixels_works_with_embedded_event_signal(nxroot):
     detector.create_field('detector_number', detector_numbers_xx_yy_1234())
     create_event_data_ids_1234(detector)
     assert detector.sizes == {'dim_0': 2, 'dim_1': 2, 'event_time_zero': 4}
-    da = detector['dim_0', 0]
+    da = detector['dim_0', 0]['events']
     assert_identical(
         da.bins.size().data,
         sc.array(dims=['dim_1'], unit=None, dtype='int64', values=[2, 3]),
@@ -274,28 +281,28 @@ def test_select_events_slices_underlying_event_data(nxroot):
     detector = nxroot.create_class('detector0', NXdetector)
     detector.create_field('detector_number', detector_numbers_xx_yy_1234())
     create_event_data_ids_1234(detector.create_class('events', snx.NXevent_data))
-    da = detector['event_time_zero', :2]
+    da = detector['event_time_zero', :2]['events']
     assert sc.identical(
         da.bins.size().data,
         sc.array(
             dims=['dim_0', 'dim_1'], unit=None, dtype='int64', values=[[1, 1], [0, 1]]
         ),
     )
-    da = detector['event_time_zero', :3]
+    da = detector['event_time_zero', :3]['events']
     assert sc.identical(
         da.bins.size().data,
         sc.array(
             dims=['dim_0', 'dim_1'], unit=None, dtype='int64', values=[[2, 2], [0, 1]]
         ),
     )
-    da = detector['event_time_zero', 3]
+    da = detector['event_time_zero', 3]['events']
     assert sc.identical(
         da.bins.size().data,
         sc.array(
             dims=['dim_0', 'dim_1'], unit=None, dtype='int64', values=[[0, 1], [0, 0]]
         ),
     )
-    da = detector[()]
+    da = detector[()]['events']
     assert sc.identical(
         da.bins.size().data,
         sc.array(
@@ -308,7 +315,7 @@ def test_loading_event_data_without_detector_numbers_does_not_group_events(nxroo
     detector = nxroot.create_class('detector0', NXdetector)
     create_event_data_ids_1234(detector.create_class('events', snx.NXevent_data))
     assert detector.dims == ('event_time_zero',)
-    da = detector[...]
+    da = detector[...]['events']
     assert_identical(
         da.bins.size().data,
         sc.array(
@@ -351,7 +358,7 @@ def test_nxevent_data_without_detector_number_selection_yields_correct_pulses(nx
 
     class Load:
         def __getitem__(self, select=...):
-            da = detector[select]
+            da = detector[select]['events']
             assert (
                 da.bins.size().sum().value
                 == da.bins.constituents['data'].sizes['event']
@@ -385,7 +392,7 @@ def test_nxevent_data_selection_yields_correct_pulses(nxroot):
 
     class Load:
         def __getitem__(self, select=...):
-            da = detector[select]
+            da = detector[select]['events']
             return da.bins.size().values
 
     assert np.array_equal(Load()[...], [2, 3, 0, 1])
@@ -449,7 +456,7 @@ def test_loads_data_with_coords_and_off_geometry(nxroot, detid_name):
     detector._group.attrs['axes'] = ['xx', 'yy']
     expected = create_off_geometry_detector_numbers_1234(detector, name='shape')
     loaded = detector[...]
-    assert_identical(loaded.coords['shape'].value, expected)
+    assert_identical(loaded['shape'], expected)
 
 
 def test_missing_detector_numbers_given_off_geometry_with_det_faces_loads_as_usual(
@@ -461,10 +468,12 @@ def test_missing_detector_numbers_given_off_geometry_with_det_faces_loads_as_usu
     detector._group.attrs['axes'] = ['xx', 'yy']
     expected = create_off_geometry_detector_numbers_1234(detector, name='shape')
     loaded = detector[...]
-    assert_identical(loaded.coords['shape'].value, expected)
+    assert_identical(loaded['shape'], expected)
 
 
-def test_off_geometry_without_detector_faces_loaded_as_0d_with_multiple_faces(nxroot):
+def test_off_geometry_without_detector_faces_loaded_on_top_level_with_multiple_faces(
+    nxroot,
+):
     var = sc.array(dims=['xx', 'yy'], unit='K', values=[[1.1, 2.2], [3.3, 4.4]])
     detector = nxroot.create_class('detector0', NXdetector)
     detector.create_field('data', var)
@@ -473,8 +482,8 @@ def test_off_geometry_without_detector_faces_loaded_as_0d_with_multiple_faces(nx
         detector, name='shape', detector_faces=False
     )
     loaded = detector[...]
-    assert_identical(loaded.coords['shape'].value, expected)
-    shape = snx.NXoff_geometry.assemble_as_child(loaded.coords['shape'].value)
+    assert_identical(loaded['shape'], expected)
+    shape = snx.NXoff_geometry.assemble_as_child(loaded['shape'])
     assert sc.identical(shape.bins.size(), sc.index(4))
 
 
@@ -498,7 +507,7 @@ def create_cylindrical_geometry_detector_numbers_1234(
     return dg
 
 
-def test_cylindrical_geometry_without_detector_numbers_loaded_as_0d(nxroot):
+def test_cylindrical_geometry_without_detector_numbers_loaded_on_top_level(nxroot):
     var = sc.array(dims=['xx', 'yy'], unit='K', values=[[1.1, 2.2], [3.3, 4.4]])
     detector = nxroot.create_class('detector0', NXdetector)
     detector.create_field('data', var)
@@ -507,8 +516,8 @@ def test_cylindrical_geometry_without_detector_numbers_loaded_as_0d(nxroot):
         detector, name='shape', detector_numbers=False
     )
     loaded = detector[...]
-    assert_identical(loaded.coords['shape'].value, expected)
-    shape = snx.NXcylindrical_geometry.assemble_as_child(loaded.coords['shape'].value)
+    assert_identical(loaded['shape'], expected)
+    shape = snx.NXcylindrical_geometry.assemble_as_child(loaded['shape'])
     assert shape.dims == ()
     assert sc.identical(shape.bins.size(), sc.index(2))
     assert sc.identical(
@@ -540,7 +549,7 @@ def test_cylindrical_geometry_with_missing_parent_detector_numbers_loads_as_usua
         detector, name='shape', detector_numbers=True
     )
     loaded = detector[...]
-    assert_identical(loaded.coords['shape'].value, expected)
+    assert_identical(loaded['shape'], expected)
 
 
 def test_cylindrical_geometry_with_inconsistent_detector_numbers_loads_as_usual(nxroot):
@@ -555,11 +564,11 @@ def test_cylindrical_geometry_with_inconsistent_detector_numbers_loads_as_usual(
         detector, name='shape', detector_numbers=True
     )
     loaded = detector[...]
-    assert_identical(loaded.coords['shape'].value, expected)
-    detector_number = loaded.coords['detector_number']
+    assert_identical(loaded['shape'], expected)
+    detector_number = loaded['data'].coords['detector_number']
     with pytest.raises(snx.NexusStructureError):
         snx.NXcylindrical_geometry.assemble_as_child(
-            loaded.coords['shape'].value, detector_number=detector_number
+            loaded['shape'], detector_number=detector_number
         )
 
 
@@ -574,9 +583,9 @@ def test_cylindrical_geometry_with_detector_numbers(nxroot):
         detector, name='shape', detector_numbers=True
     )
     loaded = detector[...]
-    assert_identical(loaded.coords['shape'].value, expected)
+    assert_identical(loaded['shape'], expected)
     shape = snx.NXcylindrical_geometry.assemble_as_child(
-        loaded.coords['shape'].value, detector_number=loaded.coords['detector_number']
+        loaded['shape'], detector_number=loaded['data'].coords['detector_number']
     )
     assert shape.dims == detector_number.dims
     for i in [0, 3]:

--- a/tests/nxdetector_test.py
+++ b/tests/nxdetector_test.py
@@ -695,3 +695,128 @@ def test_falls_back_to_hdf5_dim_labels_given_partially_axes(h5root):
     dg = detector[()]
     assert_identical(dg['xy'], xy)
     assert_identical(dg['z'], z)
+
+
+@pytest.mark.parametrize('dtype', ('bool', 'int8', 'int16', 'int32', 'int64'))
+def test_pixel_masks_parses_masks_correctly(h5root, dtype):
+    if dtype == 'bool':
+        bitmask = np.array([[1, 0], [0, 0]], dtype=dtype)
+    elif dtype in ('int8', 'int16'):
+        bitmask = np.array([[1, 2], [0, 0]], dtype=dtype)
+    else:
+        bitmask = np.array([[1, 2], [2**17, 0]], dtype=dtype)
+
+    da = sc.DataArray(
+        sc.array(dims=['xx', 'yy'], unit='K', values=[[1.1, 2.2], [3.3, 4.4]])
+    )
+    da.coords['detector_numbers'] = detector_numbers_xx_yy_1234()
+    da.coords['xx'] = sc.array(dims=['xx'], unit='m', values=[0.1, 0.2])
+    detector = snx.create_class(h5root, 'detector0', NXdetector)
+    snx.create_field(detector, 'detector_numbers', da.coords['detector_numbers'])
+    snx.create_field(detector, 'xx', da.coords['xx'])
+    snx.create_field(detector, 'data', da.data)
+    snx.create_field(detector, 'pixel_mask', bitmask)
+    snx.create_field(detector, 'pixel_mask_2', bitmask)
+    detector.attrs['axes'] = ['xx', '.']
+    detector = make_group(detector)
+    da = detector[...]['data']
+
+    assert_identical(
+        da.masks.get('gap_pixel'),
+        sc.array(
+            dims=(
+                'dim_1',
+                'xx',
+            ),
+            values=[[1, 0], [0, 0]],
+            dtype='bool',
+        ),
+    )
+    assert_identical(
+        da.masks.get('gap_pixel_2'),
+        sc.array(
+            dims=(
+                'dim_1',
+                'xx',
+            ),
+            values=[[1, 0], [0, 0]],
+            dtype='bool',
+        ),
+    )
+
+    # A 'boolean' bitmask can only define one mask
+    if dtype == 'bool':
+        assert len(da.masks) == 2
+        return
+
+    assert_identical(
+        da.masks.get('dead_pixel'),
+        sc.array(
+            dims=(
+                'dim_1',
+                'xx',
+            ),
+            values=[[0, 1], [0, 0]],
+            dtype='bool',
+        ),
+    )
+    assert_identical(
+        da.masks.get('dead_pixel_2'),
+        sc.array(
+            dims=(
+                'dim_1',
+                'xx',
+            ),
+            values=[[0, 1], [0, 0]],
+            dtype='bool',
+        ),
+    )
+
+    if dtype in ('int8', 'int16'):
+        assert len(da.masks) == 4
+        return
+
+    assert_identical(
+        da.masks.get('undefined_bit17_pixel'),
+        sc.array(
+            dims=(
+                'dim_1',
+                'xx',
+            ),
+            values=[[0, 0], [1, 0]],
+            dtype='bool',
+        ),
+    )
+    assert_identical(
+        da.masks.get('undefined_bit17_pixel_2'),
+        sc.array(
+            dims=(
+                'dim_1',
+                'xx',
+            ),
+            values=[[0, 0], [1, 0]],
+            dtype='bool',
+        ),
+    )
+    assert len(da.masks) == 6
+
+
+def test_pixel_masks_adds_mask_to_all_dataarrays_of_dataset(h5root):
+    bitmask = 1 << np.array([[0, 1], [-1, -1]])
+    da = sc.DataArray(
+        sc.array(dims=['xx', 'yy'], unit='K', values=[[1.1, 2.2], [3.3, 4.4]])
+    )
+    da.coords['detector_numbers'] = detector_numbers_xx_yy_1234()
+    da.coords['xx'] = sc.array(dims=['xx'], unit='m', values=[0.1, 0.2])
+    detector = snx.create_class(h5root, 'detector0', NXdetector)
+    snx.create_field(detector, 'detector_numbers', da.coords['detector_numbers'])
+    snx.create_field(detector, 'xx', da.coords['xx'])
+    snx.create_field(detector, 'data', da.data)
+    snx.create_field(detector, 'data_2', da.data)
+    detector.attrs['auxiliary_signals'] = ['data_2']
+    snx.create_field(detector, 'pixel_mask', bitmask)
+    detector.attrs['axes'] = ['xx', '.']
+    detector = make_group(detector)
+    dg = detector[...]
+    assert set(dg['data'].masks.keys()) == set(('gap_pixel', 'dead_pixel'))
+    assert set(dg['data_2'].masks.keys()) == set(('gap_pixel', 'dead_pixel'))

--- a/tests/nxevent_data_test.py
+++ b/tests/nxevent_data_test.py
@@ -71,7 +71,7 @@ def test_event_data_without_event_id_can_be_loaded(nxroot):
 def test_event_mode_monitor_without_event_id_can_be_loaded(nxroot):
     monitor = nxroot['entry'].create_class('monitor', snx.NXmonitor)
     create_event_data_without_event_id(monitor)
-    da = monitor[...]
+    da = monitor[...]['events']
     assert 'event_time_offset' in da.bins.coords
 
 

--- a/tests/nxmonitor_test.py
+++ b/tests/nxmonitor_test.py
@@ -34,7 +34,7 @@ def test_dense_monitor(h5root):
     data.attrs['axes'] = 'time_of_flight'
     snx.create_field(monitor, 'time_of_flight', da.coords['time_of_flight'])
     monitor = make_group(monitor)
-    assert sc.identical(monitor[...], da)
+    assert sc.identical(monitor[...]['data'], da)
 
 
 def create_event_data_no_ids(group):
@@ -55,7 +55,7 @@ def test_loads_event_data_in_current_group_as_data_array(group):
     create_event_data_no_ids(monitor)
     assert monitor.dims == ('event_time_zero',)
     assert monitor.shape == (4,)
-    loaded = monitor[...]
+    loaded = monitor[...]['events']
     assert_identical(
         loaded.bins.size().data,
         sc.array(
@@ -70,9 +70,10 @@ def test_loads_event_data_in_child_group_as_data_array(group):
     assert monitor.dims == ('event_time_zero',)
     assert monitor.shape == (4,)
     loaded = monitor[...]
-    assert isinstance(loaded, sc.DataArray)
+    assert isinstance(loaded, sc.DataGroup)
+    assert isinstance(loaded['events'], sc.DataArray)
     assert sc.identical(
-        loaded.bins.size().data,
+        loaded['events'].bins.size().data,
         sc.array(
             dims=['event_time_zero'], unit=None, dtype='int64', values=[3, 0, 2, 1]
         ),

--- a/tests/nxtransformations_test.py
+++ b/tests/nxtransformations_test.py
@@ -156,9 +156,9 @@ def test_chain_with_single_values_and_different_unit(h5root):
     )
     detector = make_group(h5root['detector_0'])
     loaded = detector[()]
-    depends_on = loaded.coords['depends_on']
-    assert depends_on.value == 'transformations/t1'
-    transforms = loaded.coords['transformations'].value
+    depends_on = loaded['depends_on']
+    assert depends_on == 'transformations/t1'
+    transforms = loaded['transformations']
     assert_identical(transforms['t1'].data, t1)
     assert transforms['t1'].attrs['depends_on'].value == 't2'
     assert_identical(transforms['t2'].data, t2)
@@ -232,10 +232,10 @@ def test_chain_with_multiple_values(h5root):
     expected2 = t
     expected2.attrs['depends_on'] = sc.scalar('.')
     detector = make_group(detector)[()]
-    depends_on = detector.coords['depends_on']
-    assert depends_on.value == 'transformations/t1'
-    assert_identical(detector.coords['transformations'].value['t1'], expected1)
-    assert_identical(detector.coords['transformations'].value['t2'], expected2)
+    depends_on = detector['depends_on']
+    assert depends_on == 'transformations/t1'
+    assert_identical(detector['transformations']['t1'], expected1)
+    assert_identical(detector['transformations']['t2'], expected2)
 
 
 def test_chain_with_multiple_values_and_different_time_unit(h5root):
@@ -282,10 +282,10 @@ def test_chain_with_multiple_values_and_different_time_unit(h5root):
 
     detector = make_group(detector)
     loaded = detector[...]
-    depends_on = loaded.coords['depends_on']
-    assert depends_on.value == 'transformations/t1'
-    assert_identical(loaded.coords['transformations'].value['t1'], expected1)
-    assert_identical(loaded.coords['transformations'].value['t2'], expected2)
+    depends_on = loaded['depends_on']
+    assert depends_on == 'transformations/t1'
+    assert_identical(loaded['transformations']['t1'], expected1)
+    assert_identical(loaded['transformations']['t2'], expected2)
 
 
 def test_broken_time_dependent_transformation_returns_datagroup_but_sets_up_depends_on(
@@ -317,7 +317,7 @@ def test_broken_time_dependent_transformation_returns_datagroup_but_sets_up_depe
 
     detector = make_group(detector)
     loaded = detector[()]
-    t = loaded.coords['transformations'].value
+    t = loaded['transformations']
     assert isinstance(t, sc.DataGroup)
     # Due to the way NXtransformations works, vital information is stored in the
     # attributes. DataGroup does currently not support attributes, so this information
@@ -325,8 +325,8 @@ def test_broken_time_dependent_transformation_returns_datagroup_but_sets_up_depe
     t1 = t['t1']
     assert isinstance(t1, sc.DataGroup)
     assert t1.keys() == {'time', 'value'}
-    assert loaded.coords['depends_on'].value == 'transformations/t1'
-    assert_identical(loaded.coords['transformations'].value['t1'], t1)
+    assert loaded['depends_on'] == 'transformations/t1'
+    assert_identical(loaded['transformations']['t1'], t1)
 
 
 def write_translation(


### PR DESCRIPTION
This avoids some conceptual problems and ambiguities. I think we might need to refine some details, e.g., some scalar datasets should probably made into coords, instead of being kept in the top-level data group.

This constitutes a breaking change for users. One could probably support both approaches side-by-side by having the old and new `NXdetector` and `NXmonitor` definitions, which can be specified when opening a file using `snx.File`. Should we do that, or is our user base small enough so we can move directly?