### PR TITLE
Do not warn about fallback for empty groups

### DIFF
--- a/src/scippnexus/base.py
+++ b/src/scippnexus/base.py
@@ -357,6 +357,11 @@ class Group(Mapping):
             return self._get_children_by_nx_class(sel)
 
         dg = self._nexus.read_children(sel)
+        if not dg:
+            # Bail out early to avoid fallback warnings. Everything is optional in
+            # NeXus so we cannot assume that the group is invalid (in contrast to
+            # likely partially incomplete groups that will fail to assemble below).
+            return dg
         try:
             dg = self._nexus.assemble(dg)
         except (sc.DimensionError, NexusStructureError) as e:

--- a/tests/nexus_test.py
+++ b/tests/nexus_test.py
@@ -1,6 +1,8 @@
 # SPDX-License-Identifier: BSD-3-Clause
 # Copyright (c) 2023 Scipp contributors (https://github.com/scipp)
 
+import warnings
+
 import h5py
 import numpy as np
 import pytest
@@ -552,3 +554,11 @@ def test_create_field_saves_errors(nxroot):
     # Use allclose instead of identical because the variances are stored as stddevs
     # which loses precision.
     assert sc.allclose(loaded, data.rename_dims(d0='dim_0'))
+
+
+@pytest.mark.parametrize('nxclass', [NXlog, NXmonitor, NXdetector, NXevent_data])
+def test_empty_class_does_not_warn(nxroot, nxclass):
+    log = nxroot['entry'].create_class('log', nxclass)
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")
+        log[()]


### PR DESCRIPTION
Fixes #179.

This is not actually avoiding all warnings. In particular, I had considered not warning when an empty NXevent_data group is within an NXmonitor or NXdetector. However, follow up steps such as setting pixel masks depend on proper assembly, so I think keeping the warnings in those cases is justified.

We do however avoid warnings about many empty groups, such as NXlog, etc.