### PR TITLE
Convert offsets to float64

### DIFF
--- a/src/scippnexus/nxtransformations.py
+++ b/src/scippnexus/nxtransformations.py
@@ -380,9 +380,9 @@ def zip_pixel_offsets(x: Dict[str, sc.Variable], /) -> sc.Variable:
     """
     zero = sc.scalar(0.0, unit=x['x_pixel_offset'].unit)
     return sc.spatial.as_vectors(
-        x['x_pixel_offset'],
-        x.get('y_pixel_offset', zero),
-        x.get('z_pixel_offset', zero),
+        x['x_pixel_offset'].to(dtype='float64', copy=False),
+        x.get('y_pixel_offset', zero).to(dtype='float64', copy=False),
+        x.get('z_pixel_offset', zero).to(dtype='float64', copy=False),
     )
 
 

--- a/tests/nxtransformations_test.py
+++ b/tests/nxtransformations_test.py
@@ -587,11 +587,16 @@ def test_compute_positions(h5root):
     )
 
 
-def test_compute_positions_with_rotation(h5root):
+@pytest.mark.parametrize('dtype', ['float64', 'float32'])
+def test_compute_positions_with_rotation(h5root, dtype):
     instrument = snx.create_class(h5root, 'instrument', snx.NXinstrument)
     detector = create_detector(instrument)
-    snx.create_field(detector, 'x_pixel_offset', sc.linspace('xx', -1, 1, 2, unit='m'))
-    snx.create_field(detector, 'y_pixel_offset', sc.linspace('yy', -1, 1, 2, unit='m'))
+    snx.create_field(
+        detector, 'x_pixel_offset', sc.linspace('xx', -1, 1, 2, unit='m', dtype=dtype)
+    )
+    snx.create_field(
+        detector, 'y_pixel_offset', sc.linspace('yy', -1, 1, 2, unit='m', dtype=dtype)
+    )
     detector.attrs['axes'] = ['xx', 'yy']
     detector.attrs['x_pixel_offset_indices'] = [0]
     detector.attrs['y_pixel_offset_indices'] = [1]


### PR DESCRIPTION
When trying to load a file and compute the transformations using `compute_positions`, applying a transformation fails if the `[xyz]_pixel_offset` are `float32`, because we cannot make vectors with `float32` dtype in scipp.

With this change, we try to perform a conversion on-the-fly to float64 before sending to `sc.spatial.as_vectors()`