### PR TITLE
Relax dim-guessing logic for 2-D and higher datasets

### DIFF
--- a/src/scippnexus/nxdata.py
+++ b/src/scippnexus/nxdata.py
@@ -31,7 +31,7 @@ def _guess_dims(dims, shape, dataset: H5Dataset):
     if shape == dataset.shape:
         return dims
     if 1 < len(dataset.shape) <= len(shape):
-        # We allow exact multi-dim matches at the end, even thought there is a risk
+        # We allow exact multi-dim matches at the end, even though there is a risk
         # for ambiguity with the transpose. Since image data is very common and many
         # sensors are square, this is a hopefully reasonable compromise.
         if dataset.shape == shape[-len(dataset.shape) :]:

--- a/src/scippnexus/nxdata.py
+++ b/src/scippnexus/nxdata.py
@@ -30,6 +30,12 @@ def _guess_dims(dims, shape, dataset: H5Dataset):
         return None
     if shape == dataset.shape:
         return dims
+    if 1 < len(dataset.shape) <= len(shape):
+        # We allow exact multi-dim matches at the end, even thought there is a risk
+        # for ambiguity with the transpose. Since image data is very common and many
+        # sensors are square, this is a hopefully reasonable compromise.
+        if dataset.shape == shape[-len(dataset.shape) :]:
+            return dims[-len(dataset.shape) :]
     lut = {}
     for d, s in zip(dims, shape):
         if shape.count(s) == 1:

--- a/tests/nxdata_test.py
+++ b/tests/nxdata_test.py
@@ -159,11 +159,11 @@ def test_dim_guessing_with_ambiguous_shape_accepts_multi_dim_match_at_end(h5root
     data.attrs['axes'] = da.dims
     data.attrs['signal'] = 'signal'
     snx.create_field(data, 'signal', da.data)
-    snx.create_field(data, '2x2', da.data['aux', 0])
+    snx.create_field(data, '3x3', da.data['aux', 0])
     data = snx.Group(data, definitions=snx.base_definitions())
     loaded = data[...]
     assert_identical(loaded.data, da.data)
-    assert_identical(loaded.coords['2x2'], da.data['aux', 0])
+    assert_identical(loaded.coords['3x3'], da.data['aux', 0])
 
 
 def test_dim_guessing_with_ambiguous_shape_rejects_1d_dim_match_at_end(h5root):


### PR DESCRIPTION
This should improve functionality for legacy files containing, e.g., imaging data.