### PR TITLE
Avoid deadlock caused by functools.cached_property

### DIFF
--- a/src/scippnexus/_cache.py
+++ b/src/scippnexus/_cache.py
@@ -1,0 +1,61 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright (c) 2024 Scipp contributors (https://github.com/scipp)
+"""
+We avoid functools.cached_property due to a per-instance lock which causes
+deadlocks in multi-threaded use of ScippNexus. This lock is removed in
+Python 3.12, so we can remove this file once we drop support for Python 3.11.
+
+This file contains a 1:1 backport of Python 3.12's cached_property.
+"""
+# flake8: noqa: E501
+from types import GenericAlias
+
+_NOT_FOUND = object()
+
+
+class cached_property:
+    def __init__(self, func):
+        self.func = func
+        self.attrname = None
+        self.__doc__ = func.__doc__
+
+    def __set_name__(self, owner, name):
+        if self.attrname is None:
+            self.attrname = name
+        elif name != self.attrname:
+            raise TypeError(
+                "Cannot assign the same cached_property to two different names "
+                f"({self.attrname!r} and {name!r})."
+            )
+
+    def __get__(self, instance, owner=None):
+        if instance is None:
+            return self
+        if self.attrname is None:
+            raise TypeError(
+                "Cannot use cached_property instance without calling __set_name__ on it."
+            )
+        try:
+            cache = instance.__dict__
+        except (
+            AttributeError
+        ):  # not all objects have __dict__ (e.g. class defines slots)
+            msg = (
+                f"No '__dict__' attribute on {type(instance).__name__!r} "
+                f"instance to cache {self.attrname!r} property."
+            )
+            raise TypeError(msg) from None
+        val = cache.get(self.attrname, _NOT_FOUND)
+        if val is _NOT_FOUND:
+            val = self.func(instance)
+            try:
+                cache[self.attrname] = val
+            except TypeError:
+                msg = (
+                    f"The '__dict__' attribute on {type(instance).__name__!r} instance "
+                    f"does not support item assignment for caching {self.attrname!r} property."
+                )
+                raise TypeError(msg) from None
+        return val
+
+    __class_getitem__ = classmethod(GenericAlias)

--- a/src/scippnexus/base.py
+++ b/src/scippnexus/base.py
@@ -6,13 +6,14 @@ from __future__ import annotations
 import inspect
 import warnings
 from collections.abc import Mapping
-from functools import cached_property, lru_cache
+from functools import lru_cache
 from types import MappingProxyType
 from typing import Any, Dict, Iterator, List, Optional, Tuple, Union, overload
 
 import numpy as np
 import scipp as sc
 
+from ._cache import cached_property
 from ._common import to_child_select
 from .attrs import Attrs
 from .field import Field

--- a/src/scippnexus/field.py
+++ b/src/scippnexus/field.py
@@ -6,7 +6,6 @@ import posixpath
 import re
 import warnings
 from dataclasses import dataclass
-from functools import cached_property
 from types import MappingProxyType
 from typing import TYPE_CHECKING, Any, Dict, Optional, Tuple, Union
 
@@ -18,6 +17,7 @@ from scippnexus._common import convert_time_to_datetime64, to_plain_index
 from scippnexus._hdf5_nexus import _warn_latin1_decode
 from scippnexus.typing import H5Dataset, ScippIndex
 
+from ._cache import cached_property
 from .attrs import Attrs
 
 if TYPE_CHECKING:

--- a/src/scippnexus/nxdata.py
+++ b/src/scippnexus/nxdata.py
@@ -4,13 +4,13 @@
 from __future__ import annotations
 
 import uuid
-from functools import cached_property
 from itertools import chain
 from typing import Any, Dict, Iterable, List, Optional, Tuple, Union
 
 import numpy as np
 import scipp as sc
 
+from ._cache import cached_property
 from ._common import _to_canonical_select, convert_time_to_datetime64, to_child_select
 from .base import (
     Group,


### PR DESCRIPTION
Avoids a deadlock encountered when using ScippNexus in a threaded context, loading different files in different threads. This affected only Python<3.12, as `functools.cached_property` contained an instance-level lock.

The exact deadlock mechanism is not fully clear at this point.

Fixes #188 (as far as I can tell so far).