### PR TITLE
Use pytest importlib import mode

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,6 +54,7 @@ minversion = "7.0"
 addopts = """
 --strict-config
 --strict-markers
+--import-mode=importlib
 -ra
 -v
 -m 'not externalfile'

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,6 +2,8 @@
 # Copyright (c) 2023 Scipp contributors (https://github.com/scipp)
 
 import os
+import sys
+from pathlib import Path
 from typing import Any, List
 
 import pytest
@@ -9,6 +11,8 @@ import scipp as sc
 
 # Silence warning from Jupyter
 os.environ['JUPYTER_PLATFORM_DIRS'] = '1'
+# To import helper modules
+sys.path.insert(0, str(Path(__file__).resolve().parent))
 
 pytest.register_assert_rewrite('scipp.testing.assertions')
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,14 +2,11 @@
 # Copyright (c) 2023 Scipp contributors (https://github.com/scipp)
 
 import os
-from pathlib import Path
 from typing import Any, List
 
 import pytest
 import scipp as sc
 
-# Load the config file in the test dir instead of the user's.
-os.environ['SCIPPDIR'] = os.fspath(Path(__file__).resolve().parent)
 # Silence warning from Jupyter
 os.environ['JUPYTER_PLATFORM_DIRS'] = '1'
 

--- a/tests/load_files_test.py
+++ b/tests/load_files_test.py
@@ -2,11 +2,12 @@
 # Copyright (c) 2023 Scipp contributors (https://github.com/scipp)
 from typing import Any, Dict, Optional, Union
 
-import externalfile
 import pytest
 import scipp as sc
 
 import scippnexus as snx
+
+externalfile = pytest.importorskip('externalfile')
 
 all_files = [
     '2023/DREAM_baseline_all_dets.nxs',

--- a/tests/load_files_test.py
+++ b/tests/load_files_test.py
@@ -2,12 +2,11 @@
 # Copyright (c) 2023 Scipp contributors (https://github.com/scipp)
 from typing import Any, Dict, Optional, Union
 
+import externalfile
 import pytest
 import scipp as sc
 
 import scippnexus as snx
-
-externalfile = pytest.importorskip('externalfile')
 
 all_files = [
     '2023/DREAM_baseline_all_dets.nxs',


### PR DESCRIPTION
Part of https://github.com/scipp/scipp/issues/3344

I tried converting `externalfile` into a fixture so that tests don't need the marker, i.e., something along the lines of
```python
# in conftest.py
@pytest.mark.fixture(scope='session')
def externalfile():
    from externalfile import ExternelFile
    return ExternalFile()

# in test file
def test_foo(externalfile):
    path = externalfile.get_path(name)
    ...
```

Where `ExternalFile` is a simple class that holds the pooch inventory. Unfortunately, I didn't find a way to skip those tests via a marker. So I think we would have to move to a dedicated command line option, see the setup in Scitacean: https://github.com/SciCatProject/scitacean/blob/main/tests/conftest.py