### PR TITLE
Resolve `depends_on`-chains eagerly so positions can be computed when subgroups are loaded

### DIFF
--- a/src/scippnexus/base.py
+++ b/src/scippnexus/base.py
@@ -381,6 +381,8 @@ class Group(Mapping):
                 else:
                     grp = sel_path.parts[0]
                     return self[grp][sel_path.relative_to(grp).as_posix()]
+            elif sel == '..':
+                return self.parent
             child = self._children[sel]
             if isinstance(child, Field):
                 self._populate_fields()
@@ -407,7 +409,14 @@ class Group(Mapping):
         # For a time-dependent transformation in NXtransformations, an NXlog may
         # take the place of the `value` field. In this case, we need to read the
         # properties of the NXlog group to make the actual transformation.
-        from .nxtransformations import maybe_transformation
+        from .nxtransformations import maybe_resolve, maybe_transformation
+
+        if (
+            isinstance(dg, sc.DataGroup)
+            and (depends_on := dg.get('depends_on')) is not None
+        ):
+            if (resolved := maybe_resolve(self['depends_on'], depends_on)) is not None:
+                dg['resolved_depends_on'] = resolved
 
         return maybe_transformation(self, value=dg, sel=sel)
 

--- a/src/scippnexus/nxtransformations.py
+++ b/src/scippnexus/nxtransformations.py
@@ -104,10 +104,11 @@ class Transformation:
             if (depends_on := self.attrs.get('depends_on')) is not None:
                 if not isinstance(transform, sc.DataArray):
                     transform = sc.DataArray(transform)
-                transform.coords['depends_on'] = sc.scalar(
-                    depends_on_to_relative_path(depends_on, self._obj.parent.name)
+                relative = depends_on_to_relative_path(
+                    depends_on, self._obj.parent.name
                 )
-                if depends_on != ".":
+                transform.coords['depends_on'] = sc.scalar(relative)
+                if relative.startswith('..'):
                     try:
                         resolved = self._obj.parent[depends_on][()]
                     except Exception:  # noqa: S110

--- a/src/scippnexus/nxtransformations.py
+++ b/src/scippnexus/nxtransformations.py
@@ -108,11 +108,15 @@ class Transformation:
                     depends_on, self._obj.parent.name
                 )
                 transform.coords['depends_on'] = sc.scalar(relative)
+                # When loading a subgroup of a file there can be transformation chains
+                # that lead outside the loaded group. In this case we cannot resolve the
+                # chain after loading, so we try to resolve it directly.
                 if relative.startswith('..'):
                     try:
                         resolved = self._obj.parent[depends_on][()]
                     except Exception:  # noqa: S110
-                        # Catchall since resolving not strictly necessary
+                        # Catchall since resolving not strictly necessary, we should not
+                        # fail the rest of the loading process.
                         pass
                     else:
                         transform.coords["resolved_depends_on"] = sc.scalar(resolved)

--- a/src/scippnexus/nxtransformations.py
+++ b/src/scippnexus/nxtransformations.py
@@ -107,6 +107,14 @@ class Transformation:
                 transform.coords['depends_on'] = sc.scalar(
                     depends_on_to_relative_path(depends_on, self._obj.parent.name)
                 )
+                if depends_on != ".":
+                    try:
+                        resolved = self._obj.parent[depends_on][()]
+                    except Exception:  # noqa: S110
+                        # Catchall since resolving not strictly necessary
+                        pass
+                    else:
+                        transform.coords["resolved_depends_on"] = sc.scalar(resolved)
             return transform
         except (sc.DimensionError, sc.UnitError, TransformationError):
             # TODO We should probably try to return some other data structure and
@@ -296,6 +304,7 @@ class TransformationChainResolver:
                 depends_on = attr.value
             # If transform is time-dependent then we keep it is a DataArray, otherwise
             # we convert it to a Variable.
+            transform.coords.pop('resolved_depends_on', None)
             transform = transform if transform.coords else transform.data
         if transform.dtype in (sc.DType.translation3, sc.DType.affine_transform3):
             transform = transform.to(unit='m', copy=False)

--- a/src/scippnexus/nxtransformations.py
+++ b/src/scippnexus/nxtransformations.py
@@ -107,10 +107,9 @@ class Transformation:
             if (depends_on := self.attrs.get('depends_on')) is not None:
                 if not isinstance(transform, sc.DataArray):
                     transform = sc.DataArray(transform)
-                relative = depends_on_to_relative_path(
-                    depends_on, self._obj.parent.name
+                transform.coords['depends_on'] = sc.scalar(
+                    depends_on_to_relative_path(depends_on, self._obj.parent.name)
                 )
-                transform.coords['depends_on'] = sc.scalar(relative)
             return transform
         except (sc.DimensionError, sc.UnitError, TransformationError):
             # TODO We should probably try to return some other data structure and

--- a/tests/nxtransformations_test.py
+++ b/tests/nxtransformations_test.py
@@ -234,9 +234,7 @@ def test_chain_with_multiple_values(h5root):
     detector = make_group(detector)[()]
     depends_on = detector['depends_on']
     assert depends_on == 'transformations/t1'
-    t1 = detector['transformations']['t1']
-    assert_identical(t1.coords.pop('resolved_depends_on').value, expected2)
-    assert_identical(t1, expected1)
+    assert_identical(detector['transformations']['t1'], expected1)
     assert_identical(detector['transformations']['t2'], expected2)
 
 
@@ -286,9 +284,7 @@ def test_chain_with_multiple_values_and_different_time_unit(h5root):
     loaded = detector[...]
     depends_on = loaded['depends_on']
     assert depends_on == 'transformations/t1'
-    t1 = loaded['transformations']['t1']
-    assert_identical(t1.coords.pop('resolved_depends_on').value, expected2)
-    assert_identical(t1, expected1)
+    assert_identical(loaded['transformations']['t1'], expected1)
     assert_identical(loaded['transformations']['t2'], expected2)
 
 

--- a/tests/nxtransformations_test.py
+++ b/tests/nxtransformations_test.py
@@ -234,7 +234,9 @@ def test_chain_with_multiple_values(h5root):
     detector = make_group(detector)[()]
     depends_on = detector['depends_on']
     assert depends_on == 'transformations/t1'
-    assert_identical(detector['transformations']['t1'], expected1)
+    t1 = detector['transformations']['t1']
+    assert_identical(t1.coords.pop('resolved_depends_on').value, expected2)
+    assert_identical(t1, expected1)
     assert_identical(detector['transformations']['t2'], expected2)
 
 
@@ -284,7 +286,9 @@ def test_chain_with_multiple_values_and_different_time_unit(h5root):
     loaded = detector[...]
     depends_on = loaded['depends_on']
     assert depends_on == 'transformations/t1'
-    assert_identical(loaded['transformations']['t1'], expected1)
+    t1 = loaded['transformations']['t1']
+    assert_identical(t1.coords.pop('resolved_depends_on').value, expected2)
+    assert_identical(t1, expected1)
     assert_identical(loaded['transformations']['t2'], expected2)
 
 


### PR DESCRIPTION
### Problem description

We have recently moved to loading individual components from NeXus files, such as `NXmonitor`. After such a load `snx.compute_positions` can then not resolve `depends_on` chains that loaded outside that group.

A previous implementation attempted to perform this eagerly while loading, but it causes performance issues. For example, a Bifrost file (873855_00000015.hdf, a "known" worst case) currently loads in `1 s`, but takes more than `10 s` if we do a naive implementation that directly follows and loads each chain.

### Solution

- I tried adding a cache to a naive solution, but this still takes around `3.5 s`, and it likely introduces other problems.
- Resolving only `depends_on` attributes that lead outside the current group brings this down to `2 s`. I believe this is acceptable as most other files will see a much smaller overhead. Newer Bifrost files might also be less of an issue as it was planned to improve the chain structure (using shorter chains).

Remaining subtlety: If there is a chain with 2 jumps cut by a depend_on in the current group this implementation will not resolve the second jump. This may be rare enough to matter, so I am avoiding complications until this actually causes issues. Example:
```
group1/transformations/t1/depends_on = group2/transformations/t2
group2/transformations/t2/depends_on = t3  # breaks resolve
group2/transformations/t3/depends_on = group3/transformations/t4
grouped3/transformations/t4
```