### PR TITLE
Fix typo in autodoc generation, point towards right template

### DIFF
--- a/docs/api-reference/index.md
+++ b/docs/api-reference/index.md
@@ -95,7 +95,7 @@
 
 .. autosummary::
    :toctree: ../generated/classes
-   :template: scipp-class-template.rst
+   :template: class-template.rst
    :recursive:
 
    typing.H5Dataset

--- a/docs/api-reference/index.md
+++ b/docs/api-reference/index.md
@@ -9,7 +9,7 @@
 
 .. autosummary::
    :toctree: ../generated/classes
-   :template: scipp-class-template.rst
+   :template: class-template.rst
    :recursive:
 
    Attrs


### PR DESCRIPTION
Fixes https://github.com/scipp/scippnexus/issues/222