### PR TITLE
Fix NXcite subgroup tripping up NXdetector loading

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -61,7 +61,6 @@ addopts = """
 testpaths = "tests"
 filterwarnings = [
   "error",
-  "ignore:Failed to load :UserWarning",
 ]
 markers = [
     "externalfile",

--- a/src/scippnexus/nxdata.py
+++ b/src/scippnexus/nxdata.py
@@ -91,6 +91,7 @@ class NXdata(NXobject):
             if name == self._signal_name or name in self._aux_signals:
                 return
             if field.attrs.get('NX_class') not in [
+                'NXcite',
                 'NXoff_geometry',
                 'NXcylindrical_geometry',
                 'NXgeometry',

--- a/tests/nxdata_test.py
+++ b/tests/nxdata_test.py
@@ -149,6 +149,7 @@ def test_guessed_dim_for_2d_coord_not_matching_axis_name(h5root):
     assert sc.identical(data[...], da)
 
 
+@pytest.mark.filterwarnings("ignore:Failed to load /data1:UserWarning")
 def test_skips_axis_if_dim_guessing_finds_ambiguous_shape(h5root):
     da = sc.DataArray(
         sc.array(dims=['xx', 'yy'], unit='m', values=[[1, 2, 3], [4, 5, 6], [7, 8, 9]])
@@ -186,6 +187,7 @@ def test_dim_guessing_with_ambiguous_shape_accepts_multi_dim_match_at_end(h5root
     assert_identical(loaded.coords['3x3'], da.data['aux', 0])
 
 
+@pytest.mark.filterwarnings("ignore:Failed to load /data1:UserWarning")
 def test_dim_guessing_with_ambiguous_shape_rejects_1d_dim_match_at_end(h5root):
     da = sc.DataArray(
         sc.array(dims=['xx', 'yy'], unit='m', values=[[1, 2, 3], [4, 5, 6], [7, 8, 9]])
@@ -348,6 +350,7 @@ def test_field_dims_match_NXdata_dims_when_selected_via_class_name(h5root):
     assert fields['yy'].dims == ('yy',)
 
 
+@pytest.mark.filterwarnings("ignore:Failed to load /data1:UserWarning")
 def test_uses_default_field_dims_if_inference_fails(h5root):
     da = sc.DataArray(
         sc.array(dims=['xx', 'yy'], unit='m', values=[[1, 2, 3], [4, 5, 6]])
@@ -691,6 +694,7 @@ def test_guesses_dims_of_2d_bin_edge_fields(h5root, axis_sep):
     assert sc.identical(data[...], da)
 
 
+@pytest.mark.filterwarnings("ignore:Failed to load /data1:UserWarning")
 def test_nested_groups_trigger_fallback_to_load_as_data_group(h5root):
     da = sc.DataArray(sc.array(dims=['xx', 'yy'], unit='m', values=[[1, 2], [4, 5]]))
     data = snx.create_class(h5root, 'data1', NXdata)

--- a/tests/nxdetector_test.py
+++ b/tests/nxdetector_test.py
@@ -28,6 +28,7 @@ def nxroot():
         yield root
 
 
+@pytest.mark.filterwarnings("ignore:Failed to load :UserWarning")
 def test_returns_as_datagroup_if_no_signal_found(nxroot):
     detector_numbers = sc.array(dims=[''], unit=None, values=np.array([1, 2, 3, 4]))
     detector = nxroot.create_class('detector0', NXdetector)
@@ -675,6 +676,7 @@ def test_cylindrical_geometry_with_detector_numbers(nxroot):
         )
 
 
+@pytest.mark.filterwarnings("ignore:Failed to load :UserWarning")
 def test_falls_back_to_hdf5_dim_labels(nxroot):
     detector = nxroot.create_class('detector0', NXdetector)
     xy = sc.array(dims=['x', 'y'], values=[[1, 2], [3, 4]])
@@ -690,6 +692,7 @@ def test_falls_back_to_hdf5_dim_labels(nxroot):
     assert_identical(dg['z'], z)
 
 
+@pytest.mark.filterwarnings("ignore:Failed to load :UserWarning")
 def test_falls_back_to_partial_hdf5_dim_labels(nxroot):
     detector = nxroot.create_class('detector0', NXdetector)
     xyz = sc.ones(dims=['x', 'dim_1', 'z'], shape=(2, 2, 3))
@@ -701,6 +704,7 @@ def test_falls_back_to_partial_hdf5_dim_labels(nxroot):
     assert_identical(dg['xyz'], xyz)
 
 
+@pytest.mark.filterwarnings("ignore:Failed to load :UserWarning")
 def test_squeezes_trailing_when_fall_back_to_partial_hdf5_dim_labels(nxroot):
     detector = nxroot.create_class('detector0', NXdetector)
     x = sc.ones(dims=['x', 'dim_1'], shape=(2, 1))
@@ -711,6 +715,7 @@ def test_squeezes_trailing_when_fall_back_to_partial_hdf5_dim_labels(nxroot):
     assert_identical(dg['x'], sc.squeeze(x))
 
 
+@pytest.mark.filterwarnings("ignore:Failed to load :UserWarning")
 def test_falls_back_to_hdf5_dim_labels_given_unnamed_axes(h5root):
     xy = sc.array(dims=['x', 'y'], values=[[1, 2], [3, 4]])
     z = sc.array(dims=['z'], values=[1, 2, 3])
@@ -730,6 +735,7 @@ def test_falls_back_to_hdf5_dim_labels_given_unnamed_axes(h5root):
     assert_identical(dg['z'], z)
 
 
+@pytest.mark.filterwarnings("ignore:Failed to load :UserWarning")
 def test_falls_back_to_hdf5_dim_labels_given_partially_axes(h5root):
     xy = sc.array(dims=['x', 'yy'], values=[[1, 2], [3, 4]])
     z = sc.array(dims=['zz'], values=[1, 2, 3])

--- a/tests/nxdetector_test.py
+++ b/tests/nxdetector_test.py
@@ -145,6 +145,24 @@ def test_loads_data_with_coords(h5root):
     assert sc.identical(detector[...]['data'], da.rename_dims({'yy': 'dim_1'}))
 
 
+def test_nxcite_does_not_prevent_load_as_nxdetector(h5root):
+    da = sc.DataArray(
+        sc.array(dims=['xx', 'yy'], unit='K', values=[[1.1, 2.2], [3.3, 4.4]])
+    )
+    da.coords['detector_number'] = detector_numbers_xx_yy_1234()
+    da.coords['xx'] = sc.array(dims=['xx'], unit='m', values=[0.1, 0.2])
+    detector = snx.create_class(h5root, 'detector0', NXdetector)
+    snx.create_field(detector, 'detector_number', da.coords['detector_number'])
+    snx.create_field(detector, 'xx', da.coords['xx'])
+    snx.create_field(detector, 'data', da.data)
+    snx.create_class(detector, 'cite', snx.NXcite)
+    detector.attrs['axes'] = ['xx', '.']
+    detector = make_group(detector)
+    loaded = detector[...]
+    assert 'cite' in loaded
+    assert sc.identical(loaded['data'], da.rename_dims({'yy': 'dim_1'}))
+
+
 def test_slicing_works_as_in_scipp(h5root):
     da = sc.DataArray(
         sc.array(dims=['xx', 'yy'], unit='K', values=[[1.1, 2.2, 3.3], [3.3, 4.4, 5.5]])

--- a/tests/nxevent_data_test.py
+++ b/tests/nxevent_data_test.py
@@ -42,6 +42,7 @@ def test_negative_event_index_converted_to_num_event(nxroot):
     assert events.bins.size().values[3] == 0
 
 
+@pytest.mark.filterwarnings("ignore:Failed to load /entry/events_0:UserWarning")
 def test_bad_event_index_causes_load_as_DataGroup(nxroot):
     event_data = nxroot['entry'].create_class('events_0', snx.NXevent_data)
     event_data['event_id'] = sc.array(dims=[''], unit=None, values=[1, 2, 4, 1, 2])

--- a/tests/nxlog_test.py
+++ b/tests/nxlog_test.py
@@ -52,6 +52,7 @@ def test_nxobject_log(h5root):
     assert sc.identical(log[...], da)
 
 
+@pytest.mark.filterwarnings("ignore:Failed to load /entry/log:UserWarning")
 def test_nxlog_with_missing_value_triggers_fallback(nxroot):
     time = sc.epoch(unit='ns') + sc.array(
         dims=['time'], unit='s', values=[4.4, 5.5, 6.6]

--- a/tests/nxtransformations_test.py
+++ b/tests/nxtransformations_test.py
@@ -288,6 +288,9 @@ def test_chain_with_multiple_values_and_different_time_unit(h5root):
     assert_identical(loaded['transformations']['t2'], expected2)
 
 
+@pytest.mark.filterwarnings(
+    "ignore:Failed to load /detector_0/transformations/t1:UserWarning"
+)
 def test_broken_time_dependent_transformation_returns_datagroup_but_sets_up_depends_on(
     h5root,
 ):
@@ -660,6 +663,7 @@ def test_compute_positions_with_rotation(h5root):
     )
 
 
+@pytest.mark.filterwarnings("ignore:Failed to load /instrument/monitor:UserWarning")
 def test_compute_positions_works_for_path_beyond_root(h5root):
     instrument = snx.create_class(h5root, 'instrument', snx.NXinstrument)
     value = sc.scalar(6.5, unit='m')
@@ -684,6 +688,7 @@ def test_compute_positions_works_for_path_beyond_root(h5root):
     assert 'position' in snx.compute_positions(loaded['instrument'])['monitor2']
 
 
+@pytest.mark.filterwarnings("ignore:Failed to load /instrument/monitor:UserWarning")
 def test_path_beyond_root_is_fully_resolved_and_can_compute_positions(h5root):
     instrument = snx.create_class(h5root, 'instrument', snx.NXinstrument)
     monitor1 = snx.create_class(instrument, 'monitor1', snx.NXmonitor)
@@ -713,6 +718,7 @@ def test_path_beyond_root_is_fully_resolved_and_can_compute_positions(h5root):
     assert_identical(snx.compute_positions(mon2)['position'], 2 * value * vector)
 
 
+@pytest.mark.filterwarnings("ignore:Failed to load /instrument/monitor:UserWarning")
 def test_compute_positions_returns_position_with_unit_meters(h5root):
     instrument = snx.create_class(h5root, 'instrument', snx.NXinstrument)
     value = sc.scalar(6.5, unit='cm')
@@ -729,6 +735,7 @@ def test_compute_positions_returns_position_with_unit_meters(h5root):
     assert mon['position'].unit == 'm'
 
 
+@pytest.mark.filterwarnings("ignore:Failed to load /instrument/monitor:UserWarning")
 def test_compute_positions_handles_chains_with_mixed_units(h5root):
     instrument = snx.create_class(h5root, 'instrument', snx.NXinstrument)
     vector = sc.vector(value=[0, 0, 1])


### PR DESCRIPTION
This happens with some CODA files (seen for NMX).

Also remove a global warning ignore.