### PR TITLE
Use group axes for multi-dim NXdetector with event data

### DIFF
--- a/src/scippnexus/nxdata.py
+++ b/src/scippnexus/nxdata.py
@@ -211,7 +211,7 @@ class NXdata(NXobject):
         if self._signal is None:
             self._valid = False
         elif isinstance(self._signal, EventField):
-            # EventField uses dims of detector_number *the grouping) plus dims of event
+            # EventField uses dims of detector_number (the grouping) plus dims of event
             # data. The former may be defined by the group dims.
             if group_dims is not None:
                 self._signal._grouping.sizes = dict(

--- a/src/scippnexus/nxdata.py
+++ b/src/scippnexus/nxdata.py
@@ -211,6 +211,12 @@ class NXdata(NXobject):
         if self._signal is None:
             self._valid = False
         elif isinstance(self._signal, EventField):
+            # EventField uses dims of detector_number *the grouping) plus dims of event
+            # data. The former may be defined by the group dims.
+            if group_dims is not None:
+                self._signal._grouping.sizes = dict(
+                    zip(group_dims, self._signal.shape, strict=False)
+                )
             group_dims = self._signal.dims
         else:
             if group_dims is not None:

--- a/tests/nxdetector_test.py
+++ b/tests/nxdetector_test.py
@@ -271,6 +271,20 @@ def test_loads_event_data_with_2d_detector_numbers(nxroot):
     )
 
 
+def test_loads_event_data_with_2d_detector_numbers_and_explicit_axes(h5root):
+    detector = snx.create_class(h5root, 'detector0', NXdetector)
+    detector = make_group(detector)
+    detector.create_field('detector_number', detector_numbers_xx_yy_1234())
+    h5root['detector0'].attrs['axes'] = ['y', 'x']
+    create_event_data_ids_1234(detector.create_class('events', snx.NXevent_data))
+    assert detector.sizes == {'y': 2, 'x': 2, 'event_time_zero': 4}
+    da = detector[...]['events']
+    assert sc.identical(
+        da.bins.size().data,
+        sc.array(dims=['y', 'x'], unit=None, dtype='int64', values=[[2, 3], [0, 1]]),
+    )
+
+
 def test_selecting_pixels_works_with_event_signal(nxroot):
     detector = nxroot.create_class('detector0', NXdetector)
     detector.create_field('detector_number', detector_numbers_xx_yy_1234())


### PR DESCRIPTION
Previously such detectors were not loaded properly, with parts of the loaded group having default dims such as `[dim_0, dim_1]` whereas others had the dims given by the group `axes` and `AXISNAME_indices` attrs.