### PR TITLE
Add depends_on path to error output

### DIFF
--- a/src/scippnexus/nxtransformations.py
+++ b/src/scippnexus/nxtransformations.py
@@ -280,7 +280,8 @@ def parse_depends_on_chain(
             chain.transformations[transform.name] = transform[()]
     except KeyError as e:
         warnings.warn(
-            UserWarning(f'depends_on chain {depends_on} references missing node {e}'), stacklevel=2
+            UserWarning(f'depends_on chain {depends_on} references missing node {e}'),
+            stacklevel=2,
         )
         return None
     return chain

--- a/src/scippnexus/nxtransformations.py
+++ b/src/scippnexus/nxtransformations.py
@@ -280,7 +280,7 @@ def parse_depends_on_chain(
             chain.transformations[transform.name] = transform[()]
     except KeyError as e:
         warnings.warn(
-            UserWarning(f'depends_on chain references missing node {e}'), stacklevel=2
+            UserWarning(f'depends_on chain {depends_on} references missing node {e}'), stacklevel=2
         )
         return None
     return chain

--- a/tests/nxtransformations_test.py
+++ b/tests/nxtransformations_test.py
@@ -729,9 +729,9 @@ def test_compute_positions_warns_if_depends_on_is_dead_link(h5root):
     detector = create_detector(instrument)
     snx.create_field(detector, 'depends_on', sc.scalar('transform'))
     root = make_group(h5root)
-    with pytest.warns(UserWarning, match='depends_on chain references missing node'):
+    with pytest.warns(UserWarning, match='depends_on chain .* references missing node'):
         loaded = root[()]
-    with pytest.warns(UserWarning, match='depends_on chain references missing node'):
+    with pytest.warns(UserWarning, match='depends_on chain .* references missing node'):
         snx.compute_positions(loaded)
 
 

--- a/tests/nxtransformations_test.py
+++ b/tests/nxtransformations_test.py
@@ -729,7 +729,8 @@ def test_compute_positions_warns_if_depends_on_is_dead_link(h5root):
     detector = create_detector(instrument)
     snx.create_field(detector, 'depends_on', sc.scalar('transform'))
     root = make_group(h5root)
-    with pytest.warns(UserWarning, match='depends_on chain .* references missing node'):
+    warning_regex = r"depends_on chain .* missing node"
+    with pytest.warns(UserWarning, match=warning_regex):
         loaded = root[()]
     with pytest.warns(UserWarning, match='depends_on chain .* references missing node'):
         snx.compute_positions(loaded)

--- a/tests/nxtransformations_test.py
+++ b/tests/nxtransformations_test.py
@@ -732,7 +732,7 @@ def test_compute_positions_warns_if_depends_on_is_dead_link(h5root):
     warning_regex = r"depends_on chain .* missing node"
     with pytest.warns(UserWarning, match=warning_regex):
         loaded = root[()]
-    with pytest.warns(UserWarning, match='depends_on chain .* references missing node'):
+    with pytest.warns(UserWarning, match=warning_regex):
         snx.compute_positions(loaded)
 
 


### PR DESCRIPTION
It's hard to diagnose current web output as there is no simple way to see what is being warned about