### PR TITLE
Optimise depends_on chain resolution by using h5py

### DIFF
--- a/src/scippnexus/base.py
+++ b/src/scippnexus/base.py
@@ -222,7 +222,7 @@ class Group(Mapping):
             return NXroot
 
     @cached_property
-    def attrs(self) -> dict[str, Any]:
+    def attrs(self) -> MappingProxyType[str, Any]:
         """The attributes of the group.
 
         Cannot be used for writing attributes, since they are cached for performance."""
@@ -478,6 +478,16 @@ class Group(Mapping):
     @property
     def shape(self) -> tuple[int, ...]:
         return tuple(self.sizes.values())
+
+    @property
+    def definitions(self) -> MappingProxyType[str, str | type] | None:
+        return (
+            None if self._definitions is None else MappingProxyType(self._definitions)
+        )
+
+    @property
+    def underlying(self) -> H5Group:
+        return self._group
 
 
 def _create_field_params_numpy(data: np.ndarray):

--- a/src/scippnexus/base.py
+++ b/src/scippnexus/base.py
@@ -41,45 +41,12 @@ def is_dataset(obj: H5Group | H5Dataset) -> bool:
     return hasattr(obj, 'shape')
 
 
-_scipp_dtype = {
-    np.dtype('int8'): sc.DType.int32,
-    np.dtype('int16'): sc.DType.int32,
-    np.dtype('uint8'): sc.DType.int32,
-    np.dtype('uint16'): sc.DType.int32,
-    np.dtype('uint32'): sc.DType.int32,
-    np.dtype('uint64'): sc.DType.int64,
-    np.dtype('int32'): sc.DType.int32,
-    np.dtype('int64'): sc.DType.int64,
-    np.dtype('float32'): sc.DType.float32,
-    np.dtype('float64'): sc.DType.float64,
-    np.dtype('bool'): sc.DType.bool,
-}
-
-
-def _dtype_fromdataset(dataset: H5Dataset) -> sc.DType:
-    return _scipp_dtype.get(dataset.dtype, sc.DType.string)
-
-
-def _squeezed_field_sizes(dataset: H5Dataset) -> dict[str, int]:
-    if (shape := dataset.shape) == (1,):
-        return {}
-    return {f'dim_{i}': size for i, size in enumerate(shape)}
-
-
 class NXobject:
-    def _init_field(self, field: Field):
-        if field.sizes is None:
-            field.sizes = _squeezed_field_sizes(field.dataset)
-        field.dtype = _dtype_fromdataset(field.dataset)
-
     def __init__(self, attrs: dict[str, Any], children: dict[str, Field | Group]):
         """Subclasses should call this in their __init__ method, or ensure that they
         initialize the fields in `children` with the correct sizes and dtypes."""
         self._attrs = attrs
         self._children = children
-        for field in children.values():
-            if isinstance(field, Field):
-                self._init_field(field)
 
     @property
     def unit(self) -> None | sc.Unit:

--- a/src/scippnexus/nxdata.py
+++ b/src/scippnexus/nxdata.py
@@ -481,7 +481,6 @@ class NXlog(NXdata):
             for k in list(children):
                 if k.startswith(name):
                     field = children.pop(k)
-                    self._init_field(field)
                     field.sizes = {
                         'time' if i == 0 else f'dim_{i}': size
                         for i, size in enumerate(field.dataset.shape)

--- a/src/scippnexus/nxtransformations.py
+++ b/src/scippnexus/nxtransformations.py
@@ -314,13 +314,9 @@ def _locate_depends_on_target(
     target = file[target_path.as_posix()]
 
     if is_dataset(target):
-        from .base import _dtype_fromdataset, _squeezed_field_sizes
-
         res = Field(
             target,
             parent=Group(target.parent, definitions=definitions),
-            sizes=_squeezed_field_sizes(target),
-            dtype=_dtype_fromdataset(target),
         )
     else:
         res = Group(target, definitions=definitions)

--- a/src/scippnexus/typing.py
+++ b/src/scippnexus/typing.py
@@ -17,7 +17,7 @@ class H5Base(Protocol):
         """Name of dataset or group"""
 
     @property
-    def file(self) -> list[int]:
+    def file(self) -> Any:
         """File of dataset or group"""
 
     @property


### PR DESCRIPTION
This reduces the time it takes to resolve `depends_on` chains by locating the target using h5py and a custom path resolver. It avoids creating intermediate `snx.Group` objects which is expensive.

For loading the 45 BIFROST analysers using 
```python
def load(fname):
    start = time.perf_counter()
    with snx.File(fname) as f:
        instrument = f['entry']['instrument']
        groups = instrument[snx.NXcrystal]
        start_load = time.perf_counter()
        crystals = {k: v[()] for k, v in groups.items()}
        end_load = time.perf_counter()
    closed = time.perf_counter()
    print(f'total: {closed-start:.3f}s   load: {end_load-start_load:.3f}s')
```
I get these results on my machine:
```
# Baseline:       total: 1.205s   load: 1.082s
# Custom resolve: total: 0.345s   load: 0.306s
```