### PR TITLE
Detect cycles in depends_on

### DIFF
--- a/src/scippnexus/field.py
+++ b/src/scippnexus/field.py
@@ -1,6 +1,8 @@
 # SPDX-License-Identifier: BSD-3-Clause
 # Copyright (c) 2023 Scipp contributors (https://github.com/scipp)
 # @author Simon Heybrock
+from __future__ import annotations
+
 import datetime
 import posixpath
 import re
@@ -40,6 +42,11 @@ class DependsOn:
         if self.value == '.':
             return None
         return posixpath.normpath(posixpath.join(self.parent, self.value))
+
+    def __eq__(self, other: object) -> bool:
+        if not isinstance(other, DependsOn):
+            return NotImplemented
+        return self.absolute_path() == other.absolute_path()
 
 
 def _is_time(obj):
@@ -113,7 +120,7 @@ class Field:
     """
 
     dataset: H5Dataset
-    parent: 'Group'
+    parent: Group
     sizes: dict[str, int] | None = None
     dtype: sc.DType | None = None
     errors: H5Dataset | None = None
@@ -139,7 +146,7 @@ class Field:
         return tuple(self.sizes.values())
 
     @cached_property
-    def file(self) -> 'Group':
+    def file(self) -> Group:
         return self.parent.file
 
     def _load_variances(self, var, index):

--- a/src/scippnexus/field.py
+++ b/src/scippnexus/field.py
@@ -43,11 +43,6 @@ class DependsOn:
             return None
         return posixpath.normpath(posixpath.join(self.parent, self.value))
 
-    def __eq__(self, other: object) -> bool:
-        if not isinstance(other, DependsOn):
-            return NotImplemented
-        return self.absolute_path() == other.absolute_path()
-
 
 def _is_time(obj):
     if (unit := obj.unit) is None:

--- a/src/scippnexus/nxtransformations.py
+++ b/src/scippnexus/nxtransformations.py
@@ -322,7 +322,10 @@ def parse_depends_on_chain(
                 # detect this case.
                 chain.transformations[transform.name].depends_on = depends_on
             elif depends_on.absolute_path() in visited:
-                raise ValueError(f'Circular depends_on chain detected: {visited}')
+                raise ValueError(
+                    'Circular depends_on chain detected: '
+                    f'{[*visited, depends_on.absolute_path()]}'
+                )
             visited.append(depends_on.absolute_path())
     except KeyError as e:
         warnings.warn(

--- a/tests/nxtransformations_test.py
+++ b/tests/nxtransformations_test.py
@@ -829,3 +829,105 @@ def test_compute_transformation_warns_if_transformation_missing_vector_attr(
         UserWarning, match="Invalid transformation, missing attribute 'vector'"
     ):
         root[()]
+
+
+def test_compute_positions_terminates_with_depends_on_to_self_absolute(h5root):
+    instrument = snx.create_class(h5root, 'instrument', snx.NXinstrument)
+    detector = create_detector(instrument)
+    snx.create_field(detector, 'x_pixel_offset', sc.linspace('xx', -1, 1, 2, unit='m'))
+    snx.create_field(detector, 'y_pixel_offset', sc.linspace('yy', -1, 1, 2, unit='m'))
+    detector.attrs['axes'] = ['xx', 'yy']
+    detector.attrs['x_pixel_offset_indices'] = [0]
+    detector.attrs['y_pixel_offset_indices'] = [1]
+    snx.create_field(
+        detector, 'depends_on', sc.scalar('/instrument/detector_0/transformations/t1')
+    )
+    transformations = snx.create_class(detector, 'transformations', NXtransformations)
+    value = sc.scalar(6.5, unit='mm')
+    offset = sc.spatial.translation(value=[1, 2, 3], unit='mm')
+    vector = sc.vector(value=[0, 0, 1])
+    t = value * vector
+    value1 = snx.create_field(transformations, 't1', value)
+    value1.attrs['depends_on'] = 't2'
+    value1.attrs['transformation_type'] = 'translation'
+    value1.attrs['offset'] = offset.values
+    value1.attrs['offset_units'] = str(offset.unit)
+    value1.attrs['vector'] = vector.value
+    value2 = snx.create_field(transformations, 't2', value.to(unit='cm'))
+    value2.attrs['depends_on'] = '/instrument/detector_0/transformations/t2'
+    value2.attrs['transformation_type'] = 'translation'
+    value2.attrs['vector'] = vector.value
+
+    t1 = sc.spatial.translations(dims=t.dims, values=t.values, unit=t.unit) * offset
+    t2 = sc.spatial.translations(dims=t.dims, values=t.values, unit=t.unit).to(
+        unit='cm'
+    )
+    root = make_group(h5root)
+    loaded = root[()]
+    result = snx.compute_positions(loaded)
+    origin = sc.vector([0, 0, 0], unit='m')
+    assert_identical(
+        result['instrument']['detector_0']['position'],
+        t2.to(unit='m') * t1.to(unit='m') * origin,
+    )
+    assert_identical(
+        result['instrument']['detector_0']['data'].coords['position'],
+        t2.to(unit='m')
+        * t1.to(unit='m')
+        * sc.vectors(
+            dims=['xx', 'yy'],
+            values=[[[-1, -1, 0], [-1, 1, 0]], [[1, -1, 0], [1, 1, 0]]],
+            unit='m',
+        ),
+    )
+
+
+def test_compute_positions_terminates_with_depends_on_to_self_relative(h5root):
+    instrument = snx.create_class(h5root, 'instrument', snx.NXinstrument)
+    detector = create_detector(instrument)
+    snx.create_field(detector, 'x_pixel_offset', sc.linspace('xx', -1, 1, 2, unit='m'))
+    snx.create_field(detector, 'y_pixel_offset', sc.linspace('yy', -1, 1, 2, unit='m'))
+    detector.attrs['axes'] = ['xx', 'yy']
+    detector.attrs['x_pixel_offset_indices'] = [0]
+    detector.attrs['y_pixel_offset_indices'] = [1]
+    snx.create_field(
+        detector, 'depends_on', sc.scalar('/instrument/detector_0/transformations/t1')
+    )
+    transformations = snx.create_class(detector, 'transformations', NXtransformations)
+    value = sc.scalar(6.5, unit='mm')
+    offset = sc.spatial.translation(value=[1, 2, 3], unit='mm')
+    vector = sc.vector(value=[0, 0, 1])
+    t = value * vector
+    value1 = snx.create_field(transformations, 't1', value)
+    value1.attrs['depends_on'] = 't2'
+    value1.attrs['transformation_type'] = 'translation'
+    value1.attrs['offset'] = offset.values
+    value1.attrs['offset_units'] = str(offset.unit)
+    value1.attrs['vector'] = vector.value
+    value2 = snx.create_field(transformations, 't2', value.to(unit='cm'))
+    value2.attrs['depends_on'] = 't2'
+    value2.attrs['transformation_type'] = 'translation'
+    value2.attrs['vector'] = vector.value
+
+    t1 = sc.spatial.translations(dims=t.dims, values=t.values, unit=t.unit) * offset
+    t2 = sc.spatial.translations(dims=t.dims, values=t.values, unit=t.unit).to(
+        unit='cm'
+    )
+    root = make_group(h5root)
+    loaded = root[()]
+    result = snx.compute_positions(loaded)
+    origin = sc.vector([0, 0, 0], unit='m')
+    assert_identical(
+        result['instrument']['detector_0']['position'],
+        t2.to(unit='m') * t1.to(unit='m') * origin,
+    )
+    assert_identical(
+        result['instrument']['detector_0']['data'].coords['position'],
+        t2.to(unit='m')
+        * t1.to(unit='m')
+        * sc.vectors(
+            dims=['xx', 'yy'],
+            values=[[[-1, -1, 0], [-1, 1, 0]], [[1, -1, 0], [1, 1, 0]]],
+            unit='m',
+        ),
+    )


### PR DESCRIPTION
We have integration tests with broken files that have circular `depends_on` graphs. ScippNeXus currently runs in an infinite loop in those cases.

This PR adds
- cycles in `depends_on` chains are detected and lead to `ValueError`s.
- Self-referencing `depends_on` are treated as `depends_on == '.'`. While this does not comply with the standard, I see no reason not to do this. 