### PR TITLE
Add quiet flag for warnings

### DIFF
--- a/src/scippnexus/_load.py
+++ b/src/scippnexus/_load.py
@@ -2,6 +2,7 @@
 # Copyright (c) 2023 Scipp contributors (https://github.com/scipp)
 import contextlib
 import io
+import warnings
 from os import PathLike
 
 import h5py as h5
@@ -23,6 +24,7 @@ def load(
     root: str | None = None,
     select: ScippIndex = (),
     definitions: Definitions | DefaultDefinitionsType = DefaultDefinitions,
+    quiet: bool = False,
 ) -> sc.DataGroup | sc.DataArray | sc.Dataset:
     """Load a NeXus file.
 
@@ -83,16 +85,20 @@ def load(
     definitions:
         NeXus `application definitions <../../user-guide/application-definitions.rst>`_.
         Defaults to the ScippNexus base definitions.
+    quiet:
+        If ``True``, suppresses warnings while loading.
 
     Returns
     -------
     :
         The loaded data.
     """
-    with _open(filename, definitions=definitions) as group:
-        if root is not None:
-            group = group[root]
-        return group[select]
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore" if quiet else "default")
+        with _open(filename, definitions=definitions) as group:
+            if root is not None:
+                group = group[root]
+            return group[select]
 
 
 def _open(

--- a/tests/load_test.py
+++ b/tests/load_test.py
@@ -210,3 +210,10 @@ def test_load_from_snx_group_rejects_new_definitions(
     with pytest.raises(TypeError, match='Cannot override application definitions'):
         with snx.File(nexus_buffer, 'r') as f:
             snx.load(f, definitions=definitions)
+
+
+def test_load_suppress_warnings():
+    from scippnexus import data
+
+    filename = data.get_path('PG3_4844_event.nxs')
+    snx.load(filename, quiet=False)

--- a/tests/load_test.py
+++ b/tests/load_test.py
@@ -216,4 +216,4 @@ def test_load_suppress_warnings():
     from scippnexus import data
 
     filename = data.get_path('PG3_4844_event.nxs')
-    snx.load(filename, quiet=False)
+    snx.load(filename, quiet=True)


### PR DESCRIPTION
Using `snx.load(filename, quiet=True)` suppressed all warnings raised when loading files.

Fixes #260 