### PR TITLE
fix: use shape of grouping and not shape of grouping + shape of signal

### DIFF
--- a/src/scippnexus/nxdata.py
+++ b/src/scippnexus/nxdata.py
@@ -215,7 +215,7 @@ class NXdata(NXobject):
             # data. The former may be defined by the group dims.
             if group_dims is not None:
                 self._signal._grouping.sizes = dict(
-                    zip(group_dims, self._signal.shape, strict=False)
+                    zip(group_dims, self._signal._grouping.shape, strict=False)
                 )
             group_dims = self._signal.dims
         else:

--- a/src/scippnexus/nxdata.py
+++ b/src/scippnexus/nxdata.py
@@ -442,7 +442,10 @@ class NXdata(NXobject):
             if not isinstance(coord, sc.Variable):
                 da.coords[name] = sc.scalar(coord)
             else:
-                da.coords[name] = coord
+                if coord.shape == (1,) and not set(coord.dims).issubset(da.dims):
+                    da.coords[name] = coord[0]
+                else:
+                    da.coords[name] = coord
                 # We need the shape *before* slicing to determine dims, so we get the
                 # field from the group for the conditional.
                 da.coords.set_aligned(

--- a/src/scippnexus/nxdata.py
+++ b/src/scippnexus/nxdata.py
@@ -103,7 +103,7 @@ class NXdata(NXobject):
             # starting from the left. So we only squeeze dimensions that are after
             # len(dims).
             shape = _squeeze_trailing(dims, field.dataset.shape)
-            field.sizes = dict(zip(dims, shape, strict=True))
+            field.sizes = dict(zip(dims, shape, strict=False))
         elif self._valid:
             s1 = self._signal.sizes
             s2 = field.sizes
@@ -227,7 +227,7 @@ class NXdata(NXobject):
                 )
                 # If we have explicit group dims, we can drop trailing 1s.
                 shape = _squeeze_trailing(group_dims, shape)
-                self._signal.sizes = dict(zip(group_dims, shape, strict=True))
+                self._signal.sizes = dict(zip(group_dims, shape, strict=False))
             elif isinstance(self._signal, Group):
                 group_dims = self._signal.dims
             elif fallback_dims is not None:

--- a/tests/nxdetector_test.py
+++ b/tests/nxdetector_test.py
@@ -1004,7 +1004,7 @@ def test_detector_with_event_data_and_no_event_time_zero_can_be_loaded(nxroot):
     assert_identical(pixel2, ref2)
 
 
-def test_nxdetector_can_load_detector_with_extra_length_1_axis(h5root):
+def test_nxdetector_can_load_event_detector_with_extra_length_1_axis(h5root):
     instrument = snx.create_class(h5root, 'instrument', snx.NXinstrument)
     detector_numbers = sc.array(
         dims=['xx', 'yy'], unit=None, values=np.array([[1, 2], [3, 4]])
@@ -1020,6 +1020,34 @@ def test_nxdetector_can_load_detector_with_extra_length_1_axis(h5root):
     snx.create_field(
         event_data, 'event_index', sc.array(dims=[''], unit='None', values=[0, 3, 4, 5])
     )
+
+    xpo = snx.create_field(
+        detector, 'x_pixel_offset', sc.linspace('xx', -1, 1, 2, unit='m')
+    )
+    ypo = snx.create_field(
+        detector, 'y_pixel_offset', sc.linspace('yy', -1, 1, 2, unit='m')
+    )
+    zpo = snx.create_field(
+        detector, 'z_pixel_offset', sc.array(dims=('zz',), values=[0.0], unit='m')
+    )
+    xpo.attrs['axis'] = 1
+    ypo.attrs['axis'] = 2
+    zpo.attrs['axis'] = 3
+
+    make_group(instrument)[()]
+
+
+def test_nxdetector_can_load_hist_detector_with_extra_length_1_axis(h5root):
+    instrument = snx.create_class(h5root, 'instrument', snx.NXinstrument)
+    detector_numbers = sc.array(
+        dims=['xx', 'yy'], unit=None, values=np.array([[1, 2], [3, 4]])
+    )
+
+    detector = snx.create_class(instrument, 'detector_0', snx.NXdetector)
+    snx.create_field(detector, 'detector_number', detector_numbers)
+
+    data = sc.array(dims=['xx', 'yy'], values=np.array([[1.0, 2.0], [3.0, 4.0]]))
+    snx.create_field(detector, 'data', data)
 
     xpo = snx.create_field(
         detector, 'x_pixel_offset', sc.linspace('xx', -1, 1, 2, unit='m')

--- a/tests/nxdetector_test.py
+++ b/tests/nxdetector_test.py
@@ -1011,7 +1011,6 @@ def test_nxdetector_can_load_event_detector_with_extra_length_1_axis(h5root):
     )
     detector = snx.create_class(instrument, 'detector_0', snx.NXdetector)
     snx.create_field(detector, 'detector_number', detector_numbers)
-
     event_id = sc.array(dims=[''], unit=None, values=[1, 2, 1, 1, 2, 2])
     event_time_offset = sc.array(dims=[''], unit='s', values=[11, 22, 33, 44, 55, 66])
     event_data = snx.create_class(detector, 'events', snx.NXevent_data)
@@ -1034,7 +1033,8 @@ def test_nxdetector_can_load_event_detector_with_extra_length_1_axis(h5root):
     ypo.attrs['axis'] = 2
     zpo.attrs['axis'] = 3
 
-    make_group(instrument)[()]
+    dg = make_group(instrument)[()]
+    assert dg['detector_0']['events'].coords['z_pixel_offset'].shape == ()
 
 
 def test_nxdetector_can_load_hist_detector_with_extra_length_1_axis(h5root):
@@ -1042,10 +1042,8 @@ def test_nxdetector_can_load_hist_detector_with_extra_length_1_axis(h5root):
     detector_numbers = sc.array(
         dims=['xx', 'yy'], unit=None, values=np.array([[1, 2], [3, 4]])
     )
-
     detector = snx.create_class(instrument, 'detector_0', snx.NXdetector)
     snx.create_field(detector, 'detector_number', detector_numbers)
-
     data = sc.array(dims=['xx', 'yy'], values=np.array([[1.0, 2.0], [3.0, 4.0]]))
     snx.create_field(detector, 'data', data)
 
@@ -1062,4 +1060,5 @@ def test_nxdetector_can_load_hist_detector_with_extra_length_1_axis(h5root):
     ypo.attrs['axis'] = 2
     zpo.attrs['axis'] = 3
 
-    make_group(instrument)[()]
+    dg = make_group(instrument)[()]
+    assert dg['detector_0']['data'].coords['z_pixel_offset'].shape == ()

--- a/tests/nxdetector_test.py
+++ b/tests/nxdetector_test.py
@@ -1002,3 +1002,36 @@ def test_detector_with_event_data_and_no_event_time_zero_can_be_loaded(nxroot):
         },
     )
     assert_identical(pixel2, ref2)
+
+
+def test_nxdetector_can_load_detector_with_extra_length_1_axis(h5root):
+    instrument = snx.create_class(h5root, 'instrument', snx.NXinstrument)
+    detector_numbers = sc.array(
+        dims=['xx', 'yy'], unit=None, values=np.array([[1, 2], [3, 4]])
+    )
+    detector = snx.create_class(instrument, 'detector_0', snx.NXdetector)
+    snx.create_field(detector, 'detector_number', detector_numbers)
+
+    event_id = sc.array(dims=[''], unit=None, values=[1, 2, 1, 1, 2, 2])
+    event_time_offset = sc.array(dims=[''], unit='s', values=[11, 22, 33, 44, 55, 66])
+    event_data = snx.create_class(detector, 'events', snx.NXevent_data)
+    snx.create_field(event_data, 'event_id', event_id)
+    snx.create_field(event_data, 'event_time_offset', event_time_offset)
+    snx.create_field(
+        event_data, 'event_index', sc.array(dims=[''], unit='None', values=[0, 3, 4, 5])
+    )
+
+    xpo = snx.create_field(
+        detector, 'x_pixel_offset', sc.linspace('xx', -1, 1, 2, unit='m')
+    )
+    ypo = snx.create_field(
+        detector, 'y_pixel_offset', sc.linspace('yy', -1, 1, 2, unit='m')
+    )
+    zpo = snx.create_field(
+        detector, 'z_pixel_offset', sc.array(dims=('zz',), values=[0.0], unit='m')
+    )
+    xpo.attrs['axis'] = 1
+    ypo.attrs['axis'] = 2
+    zpo.attrs['axis'] = 3
+
+    make_group(instrument)[()]


### PR DESCRIPTION
Fixes #259 

This change solves the issue and passes the tests, and it does seem reasonable that we don't care about the shape of the signal when assigning the size of the grouping.

However the removed comment seems to indicate that we do care.

When loading the offending file with this change the `instrument/detector_0` entry gets the somewhat cryptic sizes: `sizes={'x_pixel_offset': 1280, 'y_pixel_offset': 1280, 'face': 6, 'vertex': 8, 'winding_order': 24, 'time': 0, 'event_time_zero': 1}`

So there's still something wrong here.
