### PR TITLE
Run copier update

### DIFF
--- a/.copier-answers.yml
+++ b/.copier-answers.yml
@@ -1,5 +1,5 @@
 # Changes here will be overwritten by Copier; NEVER EDIT MANUALLY
-_commit: 18e7005
+_commit: a021314
 _src_path: gh:scipp/copier_template
 description: An h5py-like utility for NeXus files with seamless Scipp integration
 max_python: '3.13'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -68,7 +68,7 @@ jobs:
     if: github.event_name == 'release' && github.event.action == 'published'
     steps:
       - uses: actions/download-artifact@v4
-      - uses: pypa/gh-action-pypi-publish@v1.8.14
+      - uses: pypa/gh-action-pypi-publish@v1.12.4
 
   upload_conda:
     name: Deploy Conda

--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,7 @@ venv
 .venv
 
 # Caches
+*.DS_Store
 .clangd/
 *.ipynb_checkpoints
 __pycache__/

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,6 +1,29 @@
-# ScippNexus
+:::{image} _static/logo.svg
+:class: only-light
+:alt: ScippNexus
+:width: 60%
+:align: center
+:::
+:::{image} _static/logo-dark.svg
+:class: only-dark
+:alt: ScippNexus
+:width: 60%
+:align: center
+:::
 
-<span style="font-size:1.2em;font-style:italic;color:#5a5a5a">
+```{raw} html
+   <style>
+    .transparent {display: none; visibility: hidden;}
+    .transparent + a.headerlink {display: none; visibility: hidden;}
+   </style>
+```
+
+```{role} transparent
+```
+
+# {transparent}`ScippNexus`
+
+<span style="font-size:1.2em;font-style:italic;color:var(--pst-color-text-muted)">
   An h5py-like utility for NeXus files with seamless Scipp integration
   </br></br>
 </span>
@@ -21,20 +44,13 @@ This is especially powerful since a number of concepts of Scipp map well to conc
   This is modelled after h5py's support for loading slices of datasets but provides the same convenience and safety as [scipp's slicing](https://scipp.github.io/user-guide/slicing.html) by requiring specification of the dimension to slice by its name, rather than plain axis order.
 - **Physical units** are stored with most datasets in a NeXus class and are loaded as unit of the [scipp.DataArray](https://scipp.github.io/user-guide/data-structures/data-structures.html#DataArray) values or coordinates.
 
-## News
-
-- [August 2023] scippnexus-23.08.0 has been released.
-  The "v2" API is now the default.
-- [April 2023] scippnexus-23.04.0 has been released.
-  This adds `scippnexus.v2`, which provides the future API of `scippnexus`.
-  The new API avoids performance bottlenecks when working with small files that contain many groups and datasets.
-  The new behavior is also more faithful to the file content.
-  `v2` will become the default in the near future.
+:::{include} user-guide/installation.md
+:heading-offset: 1
+:::
 
 ## Get in touch
 
-- If you have questions that are not answered by these documentation pages, ask on [GitHub discussions](https://github.com/scipp/scippnexus/discussions).
-  Please include a self-contained reproducible example if possible.
+- If you have questions that are not answered by these documentation pages, ask on [discussions](https://github.com/scipp/scippnexus/discussions). Please include a self-contained reproducible example if possible.
 - Report bugs (including unclear, missing, or wrong documentation!), suggest features or view the source code [on GitHub](https://github.com/scipp/scippnexus).
 
 ```{toctree}

--- a/docs/user-guide/index.md
+++ b/docs/user-guide/index.md
@@ -5,6 +5,7 @@
 maxdepth: 2
 ---
 
+installation
 quick-start-guide
 nexus-classes
 application-definitions

--- a/docs/user-guide/installation.md
+++ b/docs/user-guide/installation.md
@@ -1,0 +1,16 @@
+# Installation
+
+To install ScippNexus and all of its dependencies, use
+
+`````{tab-set}
+````{tab-item} pip
+```sh
+pip install scippnexus
+```
+````
+````{tab-item} conda
+```sh
+conda install -c conda-forge -c scipp scippnexus
+```
+````
+`````


### PR DESCRIPTION
Run copier update, and remove outdated News section in docs index page.