### PR TITLE
Allow empty slice when loading log with sublogs

### DIFF
--- a/src/scippnexus/_common.py
+++ b/src/scippnexus/_common.py
@@ -79,9 +79,6 @@ def to_canonical_select(
         return {}
     if isinstance(select, tuple) and len(select) == 0:
         return {}
-    if select == slice(None, None, None):
-        check_1d()
-        return {}
     if isinstance(select, tuple) and isinstance(select[0], str):
         key, sel = select
         return {key: sel}

--- a/src/scippnexus/_common.py
+++ b/src/scippnexus/_common.py
@@ -79,6 +79,9 @@ def to_canonical_select(
         return {}
     if isinstance(select, tuple) and len(select) == 0:
         return {}
+    if select == slice(None, None, None):
+        check_1d()
+        return {}
     if isinstance(select, tuple) and isinstance(select[0], str):
         key, sel = select
         return {key: sel}

--- a/src/scippnexus/nxlog.py
+++ b/src/scippnexus/nxlog.py
@@ -59,7 +59,12 @@ class NXlog(NXdata):
     def read_children(self, sel: ScippIndex) -> sc.DataGroup:
         # Sublogs have distinct time axes (with a different length). Must disable
         # positional indexing.
-        if self._sublogs and ('time' in to_canonical_select(list(self.sizes), sel)):
+        canonical_sel = to_canonical_select(list(self.sizes), sel)
+        if (
+            self._sublogs
+            and 'time' in canonical_sel
+            and (len(canonical_sel) > 1 or canonical_sel['time'] != slice(None))
+        ):
             raise sc.DimensionError(
                 "Cannot positionally select time since there are multiple "
                 "time fields. Label-based selection is not supported yet."

--- a/tests/load_test.py
+++ b/tests/load_test.py
@@ -170,6 +170,28 @@ def test_load_select_unknown_dim(
         snx.load(nexus_buffer, select={'y': 3})
 
 
+@pytest.mark.parametrize('select', [..., ()])
+def test_load_select_all(
+    nexus_buffer: io.BytesIO,
+    reference_data: sc.DataGroup,
+    select: snx.typing.ScippIndex,
+) -> None:
+    loaded = snx.load(nexus_buffer, select=select)
+    sc.testing.assert_identical(loaded, reference_data)
+
+
+def test_load_select_all_slice_1d(
+    nexus_buffer: io.BytesIO,
+    reference_data: sc.DataGroup,
+) -> None:
+    # This test requires 1D data as opposed to
+    # `test_load_select_all` which supports any ndim.
+    loaded = snx.load(
+        nexus_buffer, root='entry/instrument', select=slice(None, None, None)
+    )
+    sc.testing.assert_identical(loaded, reference_data['entry']['instrument'])
+
+
 class NXdetectorTimes10(snx.NXdetector):
     def assemble(self, dg: sc.DataGroup) -> sc.DataGroup:
         return 10 * super().assemble(dg)

--- a/tests/nxlog_test.py
+++ b/tests/nxlog_test.py
@@ -184,8 +184,9 @@ def test_log_with_connection_status_raises_with_positional_and_label_indexing(
 
 
 @pytest.mark.parametrize('sublog_length', [0, 1, 2])
+@pytest.mark.parametrize('select', [(), ..., slice(None)])
 def test_log_with_connection_status_loaded_as_datagroup_containing_data_arrays(
-    h5root, sublog_length
+    h5root, sublog_length, select
 ):
     da = sc.DataArray(
         sc.array(dims=['time'], values=[1.1, 2.2, 3.3]),
@@ -202,7 +203,7 @@ def test_log_with_connection_status_loaded_as_datagroup_containing_data_arrays(
     snx.create_field(log, 'connection_status', connection_status.data)
     snx.create_field(log, 'connection_status_time', connection_status.coords['time'])
     log = snx.Group(log, definitions=snx.base_definitions())
-    loaded = log[()]
+    loaded = log[select]
     da.coords['time'] = sc.epoch(unit='s') + da.coords['time']
     connection_status.coords['time'] = (
         sc.epoch(unit='s') + connection_status.coords['time']

--- a/tests/nxlog_test.py
+++ b/tests/nxlog_test.py
@@ -181,8 +181,6 @@ def test_log_with_connection_status_raises_with_positional_and_label_indexing(
         log['time', : sc.scalar(60, unit='s')]
     with pytest.raises(sc.DimensionError):
         log[:2]
-    with pytest.raises(sc.DimensionError):
-        log[:]
 
 
 @pytest.mark.parametrize('sublog_length', [0, 1, 2])


### PR DESCRIPTION
Loading an NXlog that contians sublogs with `x[:]` raises an exception because we don't support slicing sublogs. But in this case, it should behave the same as `x[()]` or `x[...]` for 1D data. So this PR handles it this way.

I ran into this in ESSreduce when passing the default `TimeInterval` (`slice(None, None, None)`) to a loader for an NXlog.